### PR TITLE
Fix high severity glob vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,9 +29,9 @@
       }
     },
     "node_modules/@acemir/cssom": {
-      "version": "0.9.24",
-      "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.24.tgz",
-      "integrity": "sha512-5YjgMmAiT2rjJZU7XK1SNI7iqTy92DpaYVgG6x63FxkJ11UpYfLndHJATtinWJClAXiOlW9XWaUyAQf8pMrQPg==",
+      "version": "0.9.29",
+      "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.29.tgz",
+      "integrity": "sha512-G90x0VW+9nW4dFajtjCoT+NM0scAfH9Mb08IcjgFHYbfiL/lU04dTF9JuVOi3/OH+DJCQdcIseSXkdCB9Ky6JA==",
       "license": "MIT"
     },
     "node_modules/@actions/core": {
@@ -97,168 +97,7 @@
         "node": ">=16"
       }
     },
-    "node_modules/@architect/hydrate": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/@architect/hydrate/-/hydrate-4.0.10.tgz",
-      "integrity": "sha512-OLnfBneWfiU+xkdI5MqnMc2p3+7aurYr6Mo9seASbxoeCdh8wFOyqMRvtXZWrSkfc6K59ZZH8MIPEJ9RhOP/vA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@architect/inventory": "~4.0.5",
-        "@architect/utils": "~4.0.6",
-        "acorn-loose": "~8.4.0",
-        "chalk": "4.1.2",
-        "esquery": "~1.6.0",
-        "glob": "10.4.5",
-        "minimist": "~1.2.8",
-        "run-series": "~1.1.9",
-        "symlink-or-copy": "~1.3.1"
-      },
-      "bin": {
-        "arc-hydrate": "src/cli.js"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@architect/inventory": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@architect/inventory/-/inventory-4.0.9.tgz",
-      "integrity": "sha512-u2huwBc3JgiM0bGLPyBy0NjcF2mtnmFWwgFl7+E72jG3BcJl1QwQqXdaHygI2WblsH4BG8C19A47Er9QKOGdiw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@architect/asap": "~7.0.10",
-        "@architect/parser": "~7.0.1",
-        "@architect/utils": "~4.0.6",
-        "@aws-lite/client": "^0.21.1",
-        "@aws-lite/ssm": "^0.2.3",
-        "lambda-runtimes": "~2.0.5"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@architect/parser": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@architect/parser/-/parser-7.0.1.tgz",
-      "integrity": "sha512-T4Rr/eQbtg/gPvS4HcXR7zYxLJ3gEh6pSKj0s/Y1IrvJY9QG4BDAVZgE7AYGfzqymwIF0pUI2mQ91CLi2CTnQw==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@architect/utils": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@architect/utils/-/utils-4.0.6.tgz",
-      "integrity": "sha512-aa6gNNoHxgKpQrIFOa5zNW5fD10v46AE2VZNcjToxAvm//8itbIBoGw2wj8oF3gqHMKKkeLAtdO8K8tlKVN8ZA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-lite/client": "^0.21.1",
-        "chalk": "4.1.2",
-        "glob": "~10.3.12",
-        "path-sort": "~0.1.0",
-        "restore-cursor": "3.1.0",
-        "run-series": "~1.1.9",
-        "run-waterfall": "~1.1.7",
-        "sha": "~3.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@architect/utils/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@architect/utils/node_modules/glob": {
-      "version": "10.3.16",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.16.tgz",
-      "integrity": "sha512-JDKXl1DiuuHJ6fVS2FXjownaavciiHNUU4mOvV/B793RLh05vZL1rcPnCSaOgv1hDT6RDlY7AB7ZUvFYAtPgAw==",
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.1",
-        "minipass": "^7.0.4",
-        "path-scurry": "^1.11.0"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@architect/utils/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@asamuzakjp/css-color": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
-      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
-      "license": "MIT",
-      "dependencies": {
-        "@csstools/css-calc": "^2.1.3",
-        "@csstools/css-color-parser": "^3.0.9",
-        "@csstools/css-parser-algorithms": "^3.0.4",
-        "@csstools/css-tokenizer": "^3.0.3",
-        "lru-cache": "^10.4.3"
-      }
-    },
-    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "license": "ISC"
-    },
-    "node_modules/@asamuzakjp/dom-selector": {
-      "version": "6.7.4",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.7.4.tgz",
-      "integrity": "sha512-buQDjkm+wDPXd6c13534URWZqbz0RP5PAhXZ+LIoa5LgwInT9HVJvGIJivg75vi8I13CxDGdTnz+aY5YUJlIAA==",
-      "license": "MIT",
-      "dependencies": {
-        "@asamuzakjp/nwsapi": "^2.3.9",
-        "bidi-js": "^1.0.3",
-        "css-tree": "^3.1.0",
-        "is-potential-custom-element-name": "^1.0.1",
-        "lru-cache": "^11.2.2"
-      }
-    },
-    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
-      "version": "11.2.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.2.tgz",
-      "integrity": "sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==",
-      "license": "ISC",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@asamuzakjp/nwsapi": {
-      "version": "2.3.9",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
-      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
-      "license": "MIT"
-    },
-    "node_modules/@aws-lite/client": {
+    "node_modules/@architect/asap/node_modules/@aws-lite/client": {
       "version": "0.21.10",
       "resolved": "https://registry.npmjs.org/@aws-lite/client/-/client-0.21.10.tgz",
       "integrity": "sha512-fOn3lg1ynBAxqcELRf084bNJ6gu+GGoNyC+hwitW/hg3Vc1z1ZbK5HWWTrDw8HdM/fEQ0UN++g7GXVN1GVctdQ==",
@@ -285,6 +124,173 @@
       ],
       "dependencies": {
         "aws4": "^1.13.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@architect/hydrate": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@architect/hydrate/-/hydrate-5.0.1.tgz",
+      "integrity": "sha512-zje5KEhjMB54qGgfEwfFrqtiJ4/w8B/pm10Z1WXmn0P9wBVjfc8uAAC8ssVrsppNtZ6I/cSQ3dvMDOc0jYgQgA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@architect/inventory": "~5.0.0",
+        "@architect/utils": "~5.0.0",
+        "acorn-loose": "8.5.2",
+        "esquery": "1.6.0"
+      },
+      "bin": {
+        "arc-hydrate": "src/cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@architect/inventory": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@architect/inventory/-/inventory-5.0.0.tgz",
+      "integrity": "sha512-Tlwo6wVFMhIZT2k5dBrU4gr21jboAXjaPvqOYsKKeEVG+1HLTdKSWLidAvKU0qDzGeT8T6oRTMH1WDlLTmhQmw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@architect/asap": "~7.0.10",
+        "@architect/parser": "~8.0.1",
+        "@architect/utils": "~5.0.0",
+        "@aws-lite/client": "^0.23.2",
+        "@aws-lite/ssm": "^0.2.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@architect/parser": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@architect/parser/-/parser-8.0.1.tgz",
+      "integrity": "sha512-uXm4XCnMF7qeIjur69qIUiz4dq40t89M4umJW5hLZ9eEDQ2rtN/+A+kbWmbw+RV3mo2RTp4EeAb+lRnU0basew==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@architect/utils": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@architect/utils/-/utils-5.0.2.tgz",
+      "integrity": "sha512-BNVXWpkXj6kDdIu6iu3Qh+Gbl1Ml0DKIDQ7s/VLaugvUBbvs+0cm7DA+N2xF6RtzBbnUm2NoyYaGvN5/0uYoEQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-lite/client": "^0.21.1",
+        "lambda-runtimes": "2.0.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@architect/utils/node_modules/@aws-lite/client": {
+      "version": "0.21.10",
+      "resolved": "https://registry.npmjs.org/@aws-lite/client/-/client-0.21.10.tgz",
+      "integrity": "sha512-fOn3lg1ynBAxqcELRf084bNJ6gu+GGoNyC+hwitW/hg3Vc1z1ZbK5HWWTrDw8HdM/fEQ0UN++g7GXVN1GVctdQ==",
+      "license": "Apache-2.0",
+      "workspaces": [
+        "plugins/acm",
+        "plugins/apigateway",
+        "plugins/apigatewaymanagementapi",
+        "plugins/apigatewayv2",
+        "plugins/cloudformation",
+        "plugins/cloudfront",
+        "plugins/cloudwatch-logs",
+        "plugins/dynamodb",
+        "plugins/iam",
+        "plugins/lambda",
+        "plugins/organizations",
+        "plugins/rds-data",
+        "plugins/route53",
+        "plugins/s3",
+        "plugins/sns",
+        "plugins/sqs",
+        "plugins/ssm",
+        "plugins/sts"
+      ],
+      "dependencies": {
+        "aws4": "^1.13.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.7.6",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.7.6.tgz",
+      "integrity": "sha512-hBaJER6A9MpdG3WgdlOolHmbOYvSk46y7IQN/1+iqiCuUu6iWdQrs9DGKF8ocqsEqWujWf/V7b7vaDgiUmIvUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.4"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.2.4",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.4.tgz",
+      "integrity": "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "license": "MIT"
+    },
+    "node_modules/@aws-lite/client": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/@aws-lite/client/-/client-0.23.2.tgz",
+      "integrity": "sha512-K7QgDnYZfe5dTLzZPq9ZSVtpQjT3gPvowJrtzXLZxpKPPWUsyeMbUvtOgfCNemSCH2xK1YCVh7YsLNtYb6ZYtw==",
+      "license": "Apache-2.0",
+      "workspaces": [
+        "plugins/acm",
+        "plugins/apigateway",
+        "plugins/apigatewaymanagementapi",
+        "plugins/apigatewayv2",
+        "plugins/cloudformation",
+        "plugins/cloudfront",
+        "plugins/cloudwatch-logs",
+        "plugins/dynamodb",
+        "plugins/iam",
+        "plugins/lambda",
+        "plugins/organizations",
+        "plugins/rds-data",
+        "plugins/route53",
+        "plugins/s3",
+        "plugins/sns",
+        "plugins/sqs",
+        "plugins/ssm",
+        "plugins/sts"
+      ],
+      "dependencies": {
+        "aws4": "^1.13.2"
       },
       "engines": {
         "node": ">=16"
@@ -2062,9 +2068,9 @@
       }
     },
     "node_modules/@codemirror/view": {
-      "version": "6.38.8",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.38.8.tgz",
-      "integrity": "sha512-XcE9fcnkHCbWkjeKyi0lllwXmBLtyYb5dt89dJyx23I9+LSh5vZDIuk7OLG4VM1lgrXZQcY6cxyZyk5WVPRv/A==",
+      "version": "6.39.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.39.3.tgz",
+      "integrity": "sha512-ZR32LYnPMpf7XZcrYJpSrHJUHNZPTj73/amTtZLhAwzYhSKiDI2OZmCiXbTRvxL1T8X7QTHnCG+KfnRJvH/QsA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -2167,9 +2173,9 @@
       }
     },
     "node_modules/@csstools/css-syntax-patches-for-csstree": {
-      "version": "1.0.19",
-      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.19.tgz",
-      "integrity": "sha512-QW5/SM2ARltEhoKcmRI1LoLf3/C7dHGswwCnfLcoMgqurBT4f8GvwXMgAbK/FwcxthmJRK5MGTtddj0yQn0J9g==",
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.14.tgz",
+      "integrity": "sha512-zSlIxa20WvMojjpCSy8WrNpcZ61RqfTfX3XTaOeVlGJrt/8HF3YbzgFZa01yTbT4GWQLwfTcC3EB8i3XnB647Q==",
       "funding": [
         {
           "type": "github",
@@ -2183,6 +2189,9 @@
       "license": "MIT-0",
       "engines": {
         "node": ">=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
       }
     },
     "node_modules/@csstools/css-tokenizer": {
@@ -2807,9 +2816,9 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.1.tgz",
-      "integrity": "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.3.tgz",
+      "integrity": "sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2819,7 +2828,7 @@
         "globals": "^14.0.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.0",
+        "js-yaml": "^4.1.1",
         "minimatch": "^3.1.2",
         "strip-json-comments": "^3.1.1"
       },
@@ -2967,28 +2976,27 @@
       }
     },
     "node_modules/@inquirer/ansi": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.2.tgz",
-      "integrity": "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.2.tgz",
+      "integrity": "sha512-SYLX05PwJVnW+WVegZt1T4Ip1qba1ik+pNJPDiqvk6zS5Y/i8PhRzLpGEtVd7sW0G8cMtkD8t4AZYhQwm8vnww==",
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       }
     },
     "node_modules/@inquirer/checkbox": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.3.2.tgz",
-      "integrity": "sha512-VXukHf0RR1doGe6Sm4F0Em7SWYLTHSsbGfJdS9Ja2bX5/D5uwVOEjr07cncLROdBvmnvCATYEWlHqYmXv2IlQA==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.0.2.tgz",
+      "integrity": "sha512-iTPV4tMMct7iOpwer5qmTP7gjnk1VQJjsNfAaC2b8Q3qiuHM3K2yjjDr5u1MKfkrvp2JD4Flf8sIPpF21pmZmw==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^1.0.2",
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/figures": "^1.0.15",
-        "@inquirer/type": "^3.0.10",
-        "yoctocolors-cjs": "^2.1.3"
+        "@inquirer/ansi": "^2.0.2",
+        "@inquirer/core": "^11.0.2",
+        "@inquirer/figures": "^2.0.2",
+        "@inquirer/type": "^4.0.2"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -3000,16 +3008,16 @@
       }
     },
     "node_modules/@inquirer/confirm": {
-      "version": "5.1.21",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.21.tgz",
-      "integrity": "sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.0.2.tgz",
+      "integrity": "sha512-A0/13Wyi+8iFeNDX6D4zZYKPoBLIEbE4K/219qHcnpXMer2weWvaTo63+2c7mQPPA206DEMSYVOPnEw3meOlCw==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/type": "^3.0.10"
+        "@inquirer/core": "^11.0.2",
+        "@inquirer/type": "^4.0.2"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -3021,22 +3029,21 @@
       }
     },
     "node_modules/@inquirer/core": {
-      "version": "10.3.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.3.2.tgz",
-      "integrity": "sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==",
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.0.2.tgz",
+      "integrity": "sha512-lgMRx/n02ciiNELBvFLHtmcjbV5tf5D/I0UYfCg2YbTZWmBZ10/niLd3IjWBxz8LtM27xP+4oLEa06Slmb7p7A==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^1.0.2",
-        "@inquirer/figures": "^1.0.15",
-        "@inquirer/type": "^3.0.10",
+        "@inquirer/ansi": "^2.0.2",
+        "@inquirer/figures": "^2.0.2",
+        "@inquirer/type": "^4.0.2",
         "cli-width": "^4.1.0",
-        "mute-stream": "^2.0.0",
+        "mute-stream": "^3.0.0",
         "signal-exit": "^4.1.0",
-        "wrap-ansi": "^6.2.0",
-        "yoctocolors-cjs": "^2.1.3"
+        "wrap-ansi": "^9.0.2"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -3047,65 +3054,18 @@
         }
       }
     },
-    "node_modules/@inquirer/core/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@inquirer/core/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@inquirer/core/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@inquirer/core/node_modules/wrap-ansi": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@inquirer/editor": {
-      "version": "4.2.23",
-      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.23.tgz",
-      "integrity": "sha512-aLSROkEwirotxZ1pBaP8tugXRFCxW94gwrQLxXfrZsKkfjOYC1aRvAZuhpJOb5cu4IBTJdsCigUlf2iCOu4ZDQ==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.0.2.tgz",
+      "integrity": "sha512-pXQ4Nf0qmFcJuYB6NlcIIxH6l6zKOwNg1Jh/ZRdKd2dTqBB4OXKUFbFwR2K4LVXVtq15ZFFatBVT+rerYR8hWQ==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/external-editor": "^1.0.3",
-        "@inquirer/type": "^3.0.10"
+        "@inquirer/core": "^11.0.2",
+        "@inquirer/external-editor": "^2.0.2",
+        "@inquirer/type": "^4.0.2"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -3117,17 +3077,16 @@
       }
     },
     "node_modules/@inquirer/expand": {
-      "version": "4.0.23",
-      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.23.tgz",
-      "integrity": "sha512-nRzdOyFYnpeYTTR2qFwEVmIWypzdAx/sIkCMeTNTcflFOovfqUk+HcFhQQVBftAh9gmGrpFj6QcGEqrDMDOiew==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.0.2.tgz",
+      "integrity": "sha512-siFG1swxfjFIOxIcehtZkh+KUNB/YCpyfHNEGu+nC/SBXIbgUWibvThLn/WesSxLRGOeSKdNKoTm+GQCKFm6Ww==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/type": "^3.0.10",
-        "yoctocolors-cjs": "^2.1.3"
+        "@inquirer/core": "^11.0.2",
+        "@inquirer/type": "^4.0.2"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -3139,16 +3098,16 @@
       }
     },
     "node_modules/@inquirer/external-editor": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz",
-      "integrity": "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-2.0.2.tgz",
+      "integrity": "sha512-X/fMXK7vXomRWEex1j8mnj7s1mpnTeP4CO/h2gysJhHLT2WjBnLv4ZQEGpm/kcYI8QfLZ2fgW+9kTKD+jeopLg==",
       "license": "MIT",
       "dependencies": {
         "chardet": "^2.1.1",
         "iconv-lite": "^0.7.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -3160,25 +3119,25 @@
       }
     },
     "node_modules/@inquirer/figures": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.15.tgz",
-      "integrity": "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.2.tgz",
+      "integrity": "sha512-qXm6EVvQx/FmnSrCWCIGtMHwqeLgxABP8XgcaAoywsL0NFga9gD5kfG0gXiv80GjK9Hsoz4pgGwF/+CjygyV9A==",
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       }
     },
     "node_modules/@inquirer/input": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.3.1.tgz",
-      "integrity": "sha512-kN0pAM4yPrLjJ1XJBjDxyfDduXOuQHrBB8aLDMueuwUGn+vNpF7Gq7TvyVxx8u4SHlFFj4trmj+a2cbpG4Jn1g==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.0.2.tgz",
+      "integrity": "sha512-hN2YRo1QiEc9lD3mK+CPnTS4TK2RhCMmMmP4nCWwTkmQL2vx9jPJWYk+rbUZpwR1D583ZJk1FI3i9JZXIpi/qg==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/type": "^3.0.10"
+        "@inquirer/core": "^11.0.2",
+        "@inquirer/type": "^4.0.2"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -3190,16 +3149,16 @@
       }
     },
     "node_modules/@inquirer/number": {
-      "version": "3.0.23",
-      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.23.tgz",
-      "integrity": "sha512-5Smv0OK7K0KUzUfYUXDXQc9jrf8OHo4ktlEayFlelCjwMXz0299Y8OrI+lj7i4gCBY15UObk76q0QtxjzFcFcg==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.0.2.tgz",
+      "integrity": "sha512-4McnjTSYrlthNW1ojkkmP75WLRYhQs7GXm6pDDoIrHqJuV5uUYwfdbB0geHdaKMarAqJQgoOVjzIT0jdWCsKew==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/type": "^3.0.10"
+        "@inquirer/core": "^11.0.2",
+        "@inquirer/type": "^4.0.2"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -3211,17 +3170,17 @@
       }
     },
     "node_modules/@inquirer/password": {
-      "version": "4.0.23",
-      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.23.tgz",
-      "integrity": "sha512-zREJHjhT5vJBMZX/IUbyI9zVtVfOLiTO66MrF/3GFZYZ7T4YILW5MSkEYHceSii/KtRk+4i3RE7E1CUXA2jHcA==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.0.2.tgz",
+      "integrity": "sha512-oSDziMKiw4G2e4zS+0JRfxuPFFGh6N/9yUaluMgEHp2/Yyj2JGwfDO7XbwtOrxVrz+XsP/iaGyWXdQb9d8A0+g==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^1.0.2",
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/type": "^3.0.10"
+        "@inquirer/ansi": "^2.0.2",
+        "@inquirer/core": "^11.0.2",
+        "@inquirer/type": "^4.0.2"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -3233,24 +3192,24 @@
       }
     },
     "node_modules/@inquirer/prompts": {
-      "version": "7.10.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.10.1.tgz",
-      "integrity": "sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.0.2.tgz",
+      "integrity": "sha512-2zK5zY48fZcl6+gG4eqOC/UzZsJckHCRvjXoLuW4D8LKOCVGdcJiSKkLnumSZjR/6PXPINDGOrGHqNxb+sxJDg==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/checkbox": "^4.3.2",
-        "@inquirer/confirm": "^5.1.21",
-        "@inquirer/editor": "^4.2.23",
-        "@inquirer/expand": "^4.0.23",
-        "@inquirer/input": "^4.3.1",
-        "@inquirer/number": "^3.0.23",
-        "@inquirer/password": "^4.0.23",
-        "@inquirer/rawlist": "^4.1.11",
-        "@inquirer/search": "^3.2.2",
-        "@inquirer/select": "^4.4.2"
+        "@inquirer/checkbox": "^5.0.2",
+        "@inquirer/confirm": "^6.0.2",
+        "@inquirer/editor": "^5.0.2",
+        "@inquirer/expand": "^5.0.2",
+        "@inquirer/input": "^5.0.2",
+        "@inquirer/number": "^4.0.2",
+        "@inquirer/password": "^5.0.2",
+        "@inquirer/rawlist": "^5.0.2",
+        "@inquirer/search": "^4.0.2",
+        "@inquirer/select": "^5.0.2"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -3262,17 +3221,16 @@
       }
     },
     "node_modules/@inquirer/rawlist": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.1.11.tgz",
-      "integrity": "sha512-+LLQB8XGr3I5LZN/GuAHo+GpDJegQwuPARLChlMICNdwW7OwV2izlCSCxN6cqpL0sMXmbKbFcItJgdQq5EBXTw==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.0.2.tgz",
+      "integrity": "sha512-AcNALEdQKUQDeJcpC1a3YC53m1MLv+sMUS+vRZ8Qigs1Yg3Dcdtmi82rscJplogKOY8CXkKW4wvVwHS2ZjCIBQ==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/type": "^3.0.10",
-        "yoctocolors-cjs": "^2.1.3"
+        "@inquirer/core": "^11.0.2",
+        "@inquirer/type": "^4.0.2"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -3284,18 +3242,17 @@
       }
     },
     "node_modules/@inquirer/search": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.2.2.tgz",
-      "integrity": "sha512-p2bvRfENXCZdWF/U2BXvnSI9h+tuA8iNqtUKb9UWbmLYCRQxd8WkvwWvYn+3NgYaNwdUkHytJMGG4MMLucI1kA==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.0.2.tgz",
+      "integrity": "sha512-hg63w5toohdzE65S3LiGhdfIL0kT+yisbZARf7zw65PvyMUTutTN3eMAvD/B6y/25z88vTrB7kSB45Vz5CbrXg==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/figures": "^1.0.15",
-        "@inquirer/type": "^3.0.10",
-        "yoctocolors-cjs": "^2.1.3"
+        "@inquirer/core": "^11.0.2",
+        "@inquirer/figures": "^2.0.2",
+        "@inquirer/type": "^4.0.2"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -3307,19 +3264,18 @@
       }
     },
     "node_modules/@inquirer/select": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.4.2.tgz",
-      "integrity": "sha512-l4xMuJo55MAe+N7Qr4rX90vypFwCajSakx59qe/tMaC1aEHWLyw68wF4o0A4SLAY4E0nd+Vt+EyskeDIqu1M6w==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.0.2.tgz",
+      "integrity": "sha512-JygTohvQxSNnvt7IKANVlg/eds+yN5sLRilYeGc4ri/9Aqi/2QPoXBMV5Cz/L1VtQv63SnTbPXJZeCK2pSwsOA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^1.0.2",
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/figures": "^1.0.15",
-        "@inquirer/type": "^3.0.10",
-        "yoctocolors-cjs": "^2.1.3"
+        "@inquirer/ansi": "^2.0.2",
+        "@inquirer/core": "^11.0.2",
+        "@inquirer/figures": "^2.0.2",
+        "@inquirer/type": "^4.0.2"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -3331,12 +3287,12 @@
       }
     },
     "node_modules/@inquirer/type": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.10.tgz",
-      "integrity": "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.2.tgz",
+      "integrity": "sha512-cae7mzluplsjSdgFA6ACLygb5jC8alO0UUnFPyu0E7tNRPrL+q/f8VcSXp+cjZQ7l5CMpDpi2G1+IQvkOiL1Lw==",
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -3431,18 +3387,6 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
-    "node_modules/@isaacs/fs-minipass": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
-      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^7.0.4"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/@isaacs/ttlcache": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/@isaacs/ttlcache/-/ttlcache-1.4.1.tgz",
@@ -3504,9 +3448,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@lezer/common": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.3.0.tgz",
-      "integrity": "sha512-L9X8uHCYU310o99L3/MpJKYxPzXPOS7S0NmBaM7UO/x2Kb2WbmMLSkfvdr1KxRIFYOpbY0Jhn7CfLSUDzL8arQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.4.0.tgz",
+      "integrity": "sha512-DVeMRoGrgn/k45oQNu189BoW4SZwgZFzJ1+1TV5j2NJ/KFC83oa/enRqZSGshyeMk5cPWMhsKs9nx+8o0unwGg==",
       "license": "MIT"
     },
     "node_modules/@lezer/highlight": {
@@ -3530,9 +3474,9 @@
       }
     },
     "node_modules/@lezer/lr": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.3.tgz",
-      "integrity": "sha512-yenN5SqAxAPv/qMnpWW0AT7l+SxVrgG+u0tNsRQWqbrz66HIl8DnEbBObvy21J5K7+I1v7gsAnlE2VQ5yYVSeA==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.5.tgz",
+      "integrity": "sha512-/YTRKP5yPPSo1xImYQk7AZZMAgap0kegzqCSYHjAL9x1AZ0ZQW+IpcEzMKagCsbTsLnVeWkxYrCNeXG8xEPrjg==",
       "license": "MIT",
       "dependencies": {
         "@lezer/common": "^1.0.0"
@@ -3554,25 +3498,25 @@
       }
     },
     "node_modules/@mux/mux-player": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@mux/mux-player/-/mux-player-3.9.1.tgz",
-      "integrity": "sha512-buvulWJD9qevaCp02oTMezn6QKmV7OwU1WDt7In8IgOJ8GKn1ZWLvfSbWEd1s3Ea1tC33NastKVG8sYlJ7HNkA==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@mux/mux-player/-/mux-player-3.10.1.tgz",
+      "integrity": "sha512-gClop9opBvInX0ysYpaHdxpTBlTGOutSHP06SD4LlJWERqATHV+YjcykXs6thRVvqMGZg/nJyVY3Uf9GAuTZXQ==",
       "license": "MIT",
       "dependencies": {
-        "@mux/mux-video": "0.28.1",
-        "@mux/playback-core": "0.31.4",
-        "media-chrome": "~4.16.0",
+        "@mux/mux-video": "0.29.1",
+        "@mux/playback-core": "0.32.1",
+        "media-chrome": "~4.16.1",
         "player.style": "^0.3.0"
       }
     },
     "node_modules/@mux/mux-player-react": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@mux/mux-player-react/-/mux-player-react-3.9.1.tgz",
-      "integrity": "sha512-4cumt+5ObUKIZioSajLLxIghCzOn4LBcFz2mNj1OGAZGckEk8jbFB/W4o2HRlOS+4cTCEKPnOQ1l7AgjGuzZ2A==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@mux/mux-player-react/-/mux-player-react-3.10.1.tgz",
+      "integrity": "sha512-9e/JPYI35tGt2v8pfibrhdYqNy5yyWgwKq3QImh/0FzA8qH8k2wrpboXyDZ0CmrFU624Y0L/Vu438vKsbX5mNg==",
       "license": "MIT",
       "dependencies": {
-        "@mux/mux-player": "3.9.1",
-        "@mux/playback-core": "0.31.4",
+        "@mux/mux-player": "3.10.1",
+        "@mux/playback-core": "0.32.1",
         "prop-types": "^15.8.1"
       },
       "peerDependencies": {
@@ -3590,9 +3534,9 @@
       }
     },
     "node_modules/@mux/mux-player/node_modules/player.style": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/player.style/-/player.style-0.3.0.tgz",
-      "integrity": "sha512-ny1TbqA2ZsUd6jzN+F034+UMXVK7n5SrwepsrZ2gIqVz00Hn0ohCUbbUdst/2IOFCy0oiTbaOXkSFxRw1RmSlg==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/player.style/-/player.style-0.3.1.tgz",
+      "integrity": "sha512-z/T8hJGaTkHT9vdXgWdOgF37eB1FV7/j52VXQZ2lgEhpru9oT8TaUWIxp6GoxTnhPBM4X6nSbpkAHrT7UTjUKg==",
       "license": "MIT",
       "workspaces": [
         ".",
@@ -3602,39 +3546,51 @@
         "themes/*"
       ],
       "dependencies": {
-        "media-chrome": "~4.14.0"
-      }
-    },
-    "node_modules/@mux/mux-player/node_modules/player.style/node_modules/media-chrome": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/media-chrome/-/media-chrome-4.14.0.tgz",
-      "integrity": "sha512-IEdFb4blyF15vLvQzLIn6USJBv7Kf2ne+TfLQKBYI5Z0f9VEBVZz5MKy4Uhi0iA9lStl2S9ENIujJRuJIa5OiA==",
-      "license": "MIT",
-      "dependencies": {
-        "ce-la-react": "^0.3.0"
+        "media-chrome": "~4.16.1"
       }
     },
     "node_modules/@mux/mux-video": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@mux/mux-video/-/mux-video-0.28.1.tgz",
-      "integrity": "sha512-lmxPmAPtUITZ+EButcZBoVs2FZbt7UgxYV/sCVOo0kGnOCrnmqjw1G3CW9tEcFST+NzdW/nIdzpRu9kg9FxBeg==",
+      "version": "0.29.1",
+      "resolved": "https://registry.npmjs.org/@mux/mux-video/-/mux-video-0.29.1.tgz",
+      "integrity": "sha512-/fZjusOZuDpmp0CFlNLnVWV85aK7AJeCEZ/MuDdKIPkTkNyt2QnQMsKBAxpLtG7AsmAROtegTc2uaOCLW9uTgw==",
       "license": "MIT",
       "dependencies": {
         "@mux/mux-data-google-ima": "0.2.8",
-        "@mux/playback-core": "0.31.4",
+        "@mux/playback-core": "0.32.1",
         "castable-video": "~1.1.11",
         "custom-media-element": "~1.4.5",
         "media-tracks": "~0.3.4"
       }
     },
     "node_modules/@mux/playback-core": {
-      "version": "0.31.4",
-      "resolved": "https://registry.npmjs.org/@mux/playback-core/-/playback-core-0.31.4.tgz",
-      "integrity": "sha512-qQrNAAdJ7vjr1XEObE1hOUmuYngk/fjwmtYhpzkX4jJZwUC8I0rHjeFv7LXuCQD1D/mYJlWEpuyA0gPd6Y2eQw==",
+      "version": "0.32.1",
+      "resolved": "https://registry.npmjs.org/@mux/playback-core/-/playback-core-0.32.1.tgz",
+      "integrity": "sha512-d1iYtftbbnjgXhL8htT6I1Z9zPdrRVcLYbOjifr5dUoqCHsXXq4f/FDCK1P5a787ekNIEG/5BT2/vWeuvjqYig==",
       "license": "MIT",
       "dependencies": {
         "hls.js": "~1.6.15",
         "mux-embed": "^5.8.3"
+      }
+    },
+    "node_modules/@noble/ed25519": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-3.0.0.tgz",
+      "integrity": "sha512-QyteqMNm0GLqfa5SoYbSC3+Pvykwpn95Zgth4MFVSMKBB75ELl9tX1LAVsN4c3HXOrakHsF2gL4zWDAYCcsnzg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
+      "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -3701,6 +3657,15 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@oclif/core/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@oclif/core/node_modules/brace-expansion": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
@@ -3737,6 +3702,18 @@
         "node": ">=10"
       }
     },
+    "node_modules/@oclif/core/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@oclif/core/node_modules/supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -3750,6 +3727,23 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/@oclif/core/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/@oclif/plugin-help": {
@@ -3933,36 +3927,250 @@
         "node": ">=14"
       }
     },
-    "node_modules/@portabletext/keyboard-shortcuts": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@portabletext/keyboard-shortcuts/-/keyboard-shortcuts-2.1.0.tgz",
-      "integrity": "sha512-/oI0p0COD/CBFlUADiSsHwKIL5iwSyqIFnbP8bUlXVp0yfYItTjSE6L1RV4b/7JO0KG3jVdusaKjplwsdXZQPw==",
+    "node_modules/@pnpm/config.env-replace": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@pnpm/config.env-replace/-/config.env-replace-1.1.0.tgz",
+      "integrity": "sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==",
       "license": "MIT",
       "engines": {
-        "node": ">=20.19 <22 || >=22.12"
+        "node": ">=12.22.0"
       }
     },
-    "node_modules/@portabletext/patches": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@portabletext/patches/-/patches-2.0.0.tgz",
-      "integrity": "sha512-EmoUhyeOYahQrG3kafplwr/apAlNby79sKFbfLhnGZsrAXcNwyUqIHbBzBVRA1WmnpDep18VfAqs9A4mbHTQIg==",
+    "node_modules/@pnpm/network.ca-file": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@pnpm/network.ca-file/-/network.ca-file-1.0.2.tgz",
+      "integrity": "sha512-YcPQ8a0jwYU9bTdJDpXjMi7Brhkr1mXsXrUJvjqM2mQDgkRiz8jFaQGOdaLxgjtUfQgZhKy/O3cG/YwmgKaxLA==",
       "license": "MIT",
       "dependencies": {
-        "@sanity/diff-match-patch": "^3.2.0",
-        "lodash": "^4.17.21"
+        "graceful-fs": "4.2.10"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      }
+    },
+    "node_modules/@pnpm/network.ca-file/node_modules/graceful-fs": {
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+      "license": "ISC"
+    },
+    "node_modules/@pnpm/npm-conf": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@pnpm/npm-conf/-/npm-conf-2.3.1.tgz",
+      "integrity": "sha512-c83qWb22rNRuB0UaVCI0uRPNRr8Z0FWnEIvT47jiHAmOIUHbBOg5XvV7pM5x+rKn9HRpjxquDbXYSXr3fAKFcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@pnpm/config.env-replace": "^1.1.0",
+        "@pnpm/network.ca-file": "^1.0.1",
+        "config-chain": "^1.1.11"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@portabletext/block-tools": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@portabletext/block-tools/-/block-tools-4.1.11.tgz",
+      "integrity": "sha512-5etEyPbkYqIdCoCERPGuWGYlAKjtzm+B9KV/EEQQhLZ8Ecl25vdwg8akAbLG5wq0JpoA8DbIeqqQikSfy9WQAg==",
+      "license": "MIT",
+      "dependencies": {
+        "@portabletext/sanity-bridge": "^1.2.14",
+        "@portabletext/schema": "^2.1.0",
+        "@sanity/types": "^4.20.3"
       },
       "engines": {
         "node": ">=20.19 <22 || >=22.12"
       }
     },
-    "node_modules/@portabletext/react": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@portabletext/react/-/react-5.0.0.tgz",
-      "integrity": "sha512-ZEYhjsiUn2Dvrhyao3qAvi6C/re9ZBt2atp14dtwWtPruMNgp1uMf3p+URf0pEEhu+rMEh9JeK0A8FgNejEWCg==",
+    "node_modules/@portabletext/block-tools/node_modules/@sanity/types": {
+      "version": "4.21.1",
+      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-4.21.1.tgz",
+      "integrity": "sha512-v0xoriwlg6wtYMIWMy7i6VBfke/Sts/sikwW2Sd+tG55jPGBk25B9N0oymn2YsT6fFsypsP5RqIyByWYSX5lWA==",
       "license": "MIT",
       "dependencies": {
-        "@portabletext/toolkit": "^4.0.0",
-        "@portabletext/types": "^3.0.0"
+        "@sanity/client": "^7.13.2",
+        "@sanity/media-library-types": "^1.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "18 || 19"
+      }
+    },
+    "node_modules/@portabletext/editor": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/@portabletext/editor/-/editor-3.3.12.tgz",
+      "integrity": "sha512-x0z70oDaL1/3sz5qAXJrU+Gowt42FOpnt6Mx1JxlqX8Qh4zutJgLSqRQkxnRaVn001VcGQQjQbfQw51AkXmrPA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@portabletext/block-tools": "^4.1.11",
+        "@portabletext/keyboard-shortcuts": "^2.1.1",
+        "@portabletext/markdown": "^1.0.7",
+        "@portabletext/patches": "^2.0.2",
+        "@portabletext/schema": "^2.1.0",
+        "@portabletext/to-html": "^5.0.0",
+        "@sanity/schema": "^4.20.3",
+        "@sanity/types": "^4.20.3",
+        "@xstate/react": "^6.0.0",
+        "debug": "^4.4.3",
+        "react-compiler-runtime": "^1.0.0",
+        "slate": "^0.120.0",
+        "slate-dom": "^0.119.0",
+        "slate-react": "^0.120.0",
+        "xstate": "^5.24.0"
+      },
+      "engines": {
+        "node": ">=20.19 <22 || >=22.12"
+      },
+      "peerDependencies": {
+        "@portabletext/sanity-bridge": "^1.2.14",
+        "react": "^18.3 || ^19",
+        "rxjs": "^7.8.2"
+      }
+    },
+    "node_modules/@portabletext/editor/node_modules/@sanity/types": {
+      "version": "4.21.1",
+      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-4.21.1.tgz",
+      "integrity": "sha512-v0xoriwlg6wtYMIWMy7i6VBfke/Sts/sikwW2Sd+tG55jPGBk25B9N0oymn2YsT6fFsypsP5RqIyByWYSX5lWA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sanity/client": "^7.13.2",
+        "@sanity/media-library-types": "^1.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "18 || 19"
+      }
+    },
+    "node_modules/@portabletext/keyboard-shortcuts": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@portabletext/keyboard-shortcuts/-/keyboard-shortcuts-2.1.1.tgz",
+      "integrity": "sha512-9qD9xk1jG/vP5O6Ab33IL7HW0bDhJ/lTkOyeq6EDnJAqVcnaZ0mw/nBVbW+2gH5DTLVJFNJ35N/24kXHFnkEXA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19 <22 || >=22.12"
+      }
+    },
+    "node_modules/@portabletext/markdown": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@portabletext/markdown/-/markdown-1.0.7.tgz",
+      "integrity": "sha512-8geSV5vKXsnkC010JMQ3ayi5DoWSW5YtUgGSRpyQvx0KS+gpNEgLOeqBunrnceYJZumkkeaYcDG1MyT9xozQHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@portabletext/schema": "^2.1.0",
+        "@portabletext/toolkit": "^5.0.0",
+        "markdown-it": "^14.1.0"
+      },
+      "engines": {
+        "node": ">=20.19 <22 || >=22.12"
+      }
+    },
+    "node_modules/@portabletext/patches": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@portabletext/patches/-/patches-2.0.2.tgz",
+      "integrity": "sha512-KIGOvUIVfdUo7eynaZr+H9jidWlmKyC+3BGzkHUM2st4Qt50vzDUJpTM3agtUAIx3qRSzFI4yVPtsO3OkxH2Vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sanity/diff-match-patch": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=20.19 <22 || >=22.12"
+      }
+    },
+    "node_modules/@portabletext/plugin-character-pair-decorator": {
+      "version": "4.0.32",
+      "resolved": "https://registry.npmjs.org/@portabletext/plugin-character-pair-decorator/-/plugin-character-pair-decorator-4.0.32.tgz",
+      "integrity": "sha512-kfdOTEVpEKxNU5WCgw/IvNIJCGqcfzj6EsldEzmf4UsBlmYbR1qONEaaQSs96FSeyu2MlH2xCfQFcK+MXKK5Tg==",
+      "license": "MIT",
+      "dependencies": {
+        "@xstate/react": "^6.0.0",
+        "react-compiler-runtime": "^1.0.0",
+        "remeda": "^2.32.0",
+        "xstate": "^5.24.0"
+      },
+      "engines": {
+        "node": ">=20.19 <22 || >=22.12"
+      },
+      "peerDependencies": {
+        "@portabletext/editor": "^3.3.12",
+        "react": "^18.3 || ^19"
+      }
+    },
+    "node_modules/@portabletext/plugin-input-rule": {
+      "version": "1.0.32",
+      "resolved": "https://registry.npmjs.org/@portabletext/plugin-input-rule/-/plugin-input-rule-1.0.32.tgz",
+      "integrity": "sha512-NJPXaKt71hYTWPpu+ljbRcjoINEaIjvK/1Qe+zH7uVJCaxySTy3nOZnWm6jHXRKkDgXmNy06yUqlJvgPlEbRlg==",
+      "license": "MIT",
+      "dependencies": {
+        "@xstate/react": "^6.0.0",
+        "react-compiler-runtime": "^1.0.0",
+        "xstate": "^5.24.0"
+      },
+      "engines": {
+        "node": ">=20.19 <22 || >=22.12"
+      },
+      "peerDependencies": {
+        "@portabletext/editor": "^3.3.12",
+        "react": "^18.3 || ^19"
+      }
+    },
+    "node_modules/@portabletext/plugin-markdown-shortcuts": {
+      "version": "4.0.32",
+      "resolved": "https://registry.npmjs.org/@portabletext/plugin-markdown-shortcuts/-/plugin-markdown-shortcuts-4.0.32.tgz",
+      "integrity": "sha512-Y2z0iNIZhcZTSrV7FnhroMy43SRIYS5dBMJIPoSECGvXZfwrRbfZf1qUVCgdn/oAaKKd/ogSg153wpixI/yu6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@portabletext/plugin-character-pair-decorator": "^4.0.32",
+        "@portabletext/plugin-input-rule": "^1.0.32",
+        "react-compiler-runtime": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20.19 <22 || >=22.12"
+      },
+      "peerDependencies": {
+        "@portabletext/editor": "^3.3.12",
+        "react": "^18.3 || ^19"
+      }
+    },
+    "node_modules/@portabletext/plugin-one-line": {
+      "version": "3.0.32",
+      "resolved": "https://registry.npmjs.org/@portabletext/plugin-one-line/-/plugin-one-line-3.0.32.tgz",
+      "integrity": "sha512-9c5m0MxvQp/ClvnfyarUyUYM4DQKcGxGQ4eg4wN53L3xCnZ+3iaLEGwxSNVemzhseuWPuPZU3VJyZImwhNfACw==",
+      "license": "MIT",
+      "dependencies": {
+        "react-compiler-runtime": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20.19 <22 || >=22.12"
+      },
+      "peerDependencies": {
+        "@portabletext/editor": "^3.3.12",
+        "react": "^18.3 || ^19"
+      }
+    },
+    "node_modules/@portabletext/plugin-typography": {
+      "version": "4.0.32",
+      "resolved": "https://registry.npmjs.org/@portabletext/plugin-typography/-/plugin-typography-4.0.32.tgz",
+      "integrity": "sha512-grZ8tP3EA9XhaAhq2ZY7PG8r6k8Z5bGM9zcOo4t6gaNfZTubRpNzouiWBoYC8rmpVAlhzOK2SWUjSG2+i9noCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@portabletext/plugin-input-rule": "^1.0.32",
+        "react-compiler-runtime": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20.19 <22 || >=22.12"
+      },
+      "peerDependencies": {
+        "@portabletext/editor": "^3.3.12",
+        "react": "^18.3 || ^19"
+      }
+    },
+    "node_modules/@portabletext/react": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@portabletext/react/-/react-6.0.0.tgz",
+      "integrity": "sha512-8jzmFruC6fhC8A47c+RdiFfldzRq/rRW/FwRsr5ZMeNeCf3S0dXVlM/LJQRWH5JLQXbH3oxINN1UV2mbuZQJ9w==",
+      "license": "MIT",
+      "dependencies": {
+        "@portabletext/toolkit": "^5.0.0",
+        "@portabletext/types": "^4.0.0"
       },
       "engines": {
         "node": ">=20.19 <22 || >=22.12"
@@ -3971,44 +4179,71 @@
         "react": "^18.2 || ^19"
       }
     },
+    "node_modules/@portabletext/sanity-bridge": {
+      "version": "1.2.14",
+      "resolved": "https://registry.npmjs.org/@portabletext/sanity-bridge/-/sanity-bridge-1.2.14.tgz",
+      "integrity": "sha512-Is4ggV86dEMm1XjTJVLswsCeWobJm5E61T9jzm64eyr9d25oVEr9lqskxPuXemap6m9t3lnKDln/Ey/qEaAeCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@portabletext/schema": "^2.1.0",
+        "@sanity/schema": "^4.20.3",
+        "@sanity/types": "^4.20.3"
+      },
+      "engines": {
+        "node": ">=20.19 <22 || >=22.12"
+      }
+    },
+    "node_modules/@portabletext/sanity-bridge/node_modules/@sanity/types": {
+      "version": "4.21.1",
+      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-4.21.1.tgz",
+      "integrity": "sha512-v0xoriwlg6wtYMIWMy7i6VBfke/Sts/sikwW2Sd+tG55jPGBk25B9N0oymn2YsT6fFsypsP5RqIyByWYSX5lWA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sanity/client": "^7.13.2",
+        "@sanity/media-library-types": "^1.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "18 || 19"
+      }
+    },
     "node_modules/@portabletext/schema": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@portabletext/schema/-/schema-2.0.0.tgz",
-      "integrity": "sha512-RtsjsfuU/v3CeCZsIHIu6l9tyEGN8DG3xpLrWUJXVjeSVO5t4yHpCwmaB1fLruP8vQUCCRdiOtcipIFOumf9Iw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@portabletext/schema/-/schema-2.1.0.tgz",
+      "integrity": "sha512-wtTYmMslVZFlONd5Ncm8wpb3MChw6s5w73icPHPZBHd+TTJn0lMGuROHhE+9XEQuD7Ly465ooH+7T/k2eQVxHg==",
       "license": "MIT",
       "engines": {
         "node": ">=20.19 <22 || >=22.12"
       }
     },
     "node_modules/@portabletext/to-html": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@portabletext/to-html/-/to-html-4.0.1.tgz",
-      "integrity": "sha512-DBMpj3lLnQjyljyJ+rC0E2GMGaFIniLGqojTMyBCDBNRu1nxuFCmLVEw3l4mBgyFN1TGVM0mcHxII+jdPuVgaQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@portabletext/to-html/-/to-html-5.0.0.tgz",
+      "integrity": "sha512-XNr/yCS1yvcfx/rsGz82yxGtdBjqXcB0SFU5ci10M/o6BxexNTMPnLshopJgDxLQ1y0kLQBiYHUN+vbQtKqcKA==",
       "license": "MIT",
       "dependencies": {
-        "@portabletext/toolkit": "^4.0.0",
-        "@portabletext/types": "^3.0.0"
+        "@portabletext/toolkit": "^5.0.0",
+        "@portabletext/types": "^4.0.0"
       },
       "engines": {
         "node": ">=20.19 <22 || >=22.12"
       }
     },
     "node_modules/@portabletext/toolkit": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@portabletext/toolkit/-/toolkit-4.0.0.tgz",
-      "integrity": "sha512-Jj/QIy3vzZCNcxiUGM7KjGhUhyVjch+9pOzotWRARPNe07R6nbF/cRsKL70q5Xizf+6PVtFYwks4CSXKInC+wg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@portabletext/toolkit/-/toolkit-5.0.0.tgz",
+      "integrity": "sha512-jcDOv1RKO/j08pdnc/6i5tULcAzEYCR41XDVYOqmmX8bvEJbWJabhpVjHT1ls6p27v9gtA4NG2SO5xdMpgWSQQ==",
       "license": "MIT",
       "dependencies": {
-        "@portabletext/types": "^3.0.0"
+        "@portabletext/types": "^4.0.0"
       },
       "engines": {
         "node": ">=20.19 <22 || >=22.12"
       }
     },
     "node_modules/@portabletext/types": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@portabletext/types/-/types-3.0.0.tgz",
-      "integrity": "sha512-7U8+bFcnguNtXr4rwMDj0EvJJDRzLaaof2mQqCjUcqxuuJpAppFaATZgrKmPI1uBgtFMi4unk1nIaOOmLHrX8Q==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@portabletext/types/-/types-4.0.0.tgz",
+      "integrity": "sha512-mEoN82OQckrshqRx8idp+x8B/OpMfUMSjQp1w1wZFM3hf8cplGhK59Sa/UuGU6XdgAnFq90vJtnj5ejOmZmhvw==",
       "license": "MIT",
       "engines": {
         "node": ">=20.19 <22 || >=22.12"
@@ -4038,9 +4273,9 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-beta.27",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
-      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "version": "1.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.53.tgz",
+      "integrity": "sha512-vENRlFU4YbrwVqNDZ7fLvy+JR1CRkyr01jhSiDpE1u6py3OMzQfztQU2jxykW3ALNxO4kSlqIDeYyD0Y9RcQeQ==",
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -4358,26 +4593,27 @@
       }
     },
     "node_modules/@sanity/cli": {
-      "version": "4.19.0",
-      "resolved": "https://registry.npmjs.org/@sanity/cli/-/cli-4.19.0.tgz",
-      "integrity": "sha512-Sxq34GhL5Km6Ns9u2bf2EIIrgxhaOfrS34ijwJsebtGpLKm6nIjyxG1ooMRW/pGTvdV3YiVzBaVBvD3MUzGgpw==",
+      "version": "4.21.1",
+      "resolved": "https://registry.npmjs.org/@sanity/cli/-/cli-4.21.1.tgz",
+      "integrity": "sha512-Nf2/SdMTcLWyfxHsdmTX79Tqm0OTYQDsr/qKOC/Oel780expStZSba4xidu4PgZU61SuHa9qRizxhgV+mu20wA==",
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.28.5",
         "@babel/traverse": "^7.28.5",
-        "@sanity/client": "^7.12.1",
-        "@sanity/codegen": "4.19.0",
-        "@sanity/runtime-cli": "^11.1.3",
+        "@sanity/client": "^7.13.2",
+        "@sanity/codegen": "4.21.1",
+        "@sanity/runtime-cli": "^12.1.0",
         "@sanity/telemetry": "^0.8.0",
         "@sanity/template-validator": "^2.4.3",
         "chalk": "^4.1.2",
         "debug": "^4.4.3",
         "esbuild": "0.27.0",
         "esbuild-register": "^3.6.0",
-        "get-it": "^8.6.10",
-        "groq-js": "^1.21.0",
+        "get-it": "^8.7.0",
+        "get-latest-version": "^5.1.0",
+        "groq-js": "^1.23.0",
         "pkg-dir": "^5.0.0",
-        "prettier": "^3.6.2",
+        "prettier": "^3.7.3",
         "semver": "^7.7.2"
       },
       "bin": {
@@ -4865,14 +5101,14 @@
       }
     },
     "node_modules/@sanity/client": {
-      "version": "7.13.1",
-      "resolved": "https://registry.npmjs.org/@sanity/client/-/client-7.13.1.tgz",
-      "integrity": "sha512-Bs+Bg5Fd/2tSR7AYS3+ehUlHtHjrXgH9MwNfTaKUfke158KjAQ4jw1mJVX+jp+171BLwlaaVKYw+mfRkmOCvHw==",
+      "version": "7.13.2",
+      "resolved": "https://registry.npmjs.org/@sanity/client/-/client-7.13.2.tgz",
+      "integrity": "sha512-bXuQGWgrpkSInZy8lfCMmOgdTNpsoZ7PORW0+zXss8qVpNo1DC002l1c8to6kfxNF0OaL9v7LwsPqKcTZ/VWrw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@sanity/eventsource": "^5.0.2",
-        "get-it": "^8.6.9",
+        "get-it": "^8.7.0",
         "nanoid": "^3.3.11",
         "rxjs": "^7.0.0"
       },
@@ -4881,9 +5117,9 @@
       }
     },
     "node_modules/@sanity/codegen": {
-      "version": "4.19.0",
-      "resolved": "https://registry.npmjs.org/@sanity/codegen/-/codegen-4.19.0.tgz",
-      "integrity": "sha512-4PsNWgMESIodcwydH3sGl3Ga4R7FAOpM11GsFli4ESkKE7s04I8XGZdcpILr8GIU3T2y7YJerlFO7CrqVhSd2g==",
+      "version": "4.21.1",
+      "resolved": "https://registry.npmjs.org/@sanity/codegen/-/codegen-4.21.1.tgz",
+      "integrity": "sha512-8xbzXl/BPESwQv97pq9/p6t0dLEp16m/DDQLWnbTEHmkgucWaBNvVzFYPhRfysdbE3tt7e7vZNbRQQPewEyANw==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.28.5",
@@ -4896,8 +5132,8 @@
         "@babel/types": "^7.28.5",
         "debug": "^4.4.3",
         "globby": "^11.1.0",
-        "groq": "4.19.0",
-        "groq-js": "^1.21.0",
+        "groq": "4.21.1",
+        "groq-js": "^1.23.0",
         "json5": "^2.2.3",
         "tsconfig-paths": "^4.2.0",
         "zod": "^3.25.76"
@@ -4968,9 +5204,9 @@
       }
     },
     "node_modules/@sanity/descriptors": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@sanity/descriptors/-/descriptors-1.2.0.tgz",
-      "integrity": "sha512-C8QuLHwzgqCZInJDyz+V+9QnnVUI7LcNEdR+HRkll9JE6dkkjW6jG6W1md7bv7TXCYvEl0fOHDgXTB7k0ibjew==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@sanity/descriptors/-/descriptors-1.3.0.tgz",
+      "integrity": "sha512-S2KYYGRUVZy+FDjPp3meoyczbCjobSQvZcgNayo3oYlYS9Qz0E+6RezGxi/KOb6iF52Oir3LEXp9SVfIgEwNjg==",
       "license": "MIT",
       "dependencies": {
         "sha256-uint8array": "^0.10.7"
@@ -4980,9 +5216,9 @@
       }
     },
     "node_modules/@sanity/diff": {
-      "version": "4.19.0",
-      "resolved": "https://registry.npmjs.org/@sanity/diff/-/diff-4.19.0.tgz",
-      "integrity": "sha512-dcKDpb7iWzcpYzf37seWQgLRQV7BWE5eNw9iTCqkLbSZktVPFJbWk9ibvB+66vF/3z8WfxRNOb0bgSDM1/4Fbg==",
+      "version": "4.21.1",
+      "resolved": "https://registry.npmjs.org/@sanity/diff/-/diff-4.21.1.tgz",
+      "integrity": "sha512-hlRGuu6kdX3Jnju+dbF/NOKqFa0P94+1r8Is9M3KfFtXMYgXLGtNqcSAka3yCcKcwXgzLVCz4H4mFwNL4YQ+zg==",
       "license": "MIT",
       "dependencies": {
         "@sanity/diff-match-patch": "^3.2.0"
@@ -5044,24 +5280,17 @@
       }
     },
     "node_modules/@sanity/export": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@sanity/export/-/export-4.0.1.tgz",
-      "integrity": "sha512-fQYd26ooDOKsiza6ubdPla8x7sKmQGD8U1wsFEQ3RGJByQkFq1C7LbylG+4m42BMERbftkonv26XLgfN8RXZQQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@sanity/export/-/export-5.0.1.tgz",
+      "integrity": "sha512-ATHXvRNup6mTYYxlGXvJpzAodx1GuXfNcIdxy027LmAKPRoUExwp7rg2yfU/Nxu0gvpfeDbUPneJ2H5gPQmNWg==",
       "license": "MIT",
       "dependencies": {
-        "@sanity/client": "^7.8.2",
-        "@sanity/util": "^4.3.0",
-        "archiver": "^7.0.0",
+        "archiver": "^7.0.1",
         "debug": "^4.3.4",
         "get-it": "^8.6.10",
-        "json-stream-stringify": "^2.0.2",
-        "lodash": "^4.17.21",
-        "mississippi": "^4.0.0",
-        "p-queue": "^2.3.0",
-        "rimraf": "^6.0.1",
-        "split2": "^4.2.0",
-        "tar": "^7.0.1",
-        "yaml": "^2.4.2"
+        "json-stream-stringify": "^3.1.6",
+        "p-queue": "^9.0.1",
+        "rimraf": "^6.1.2"
       },
       "engines": {
         "node": ">=20.19 <22 || >=22.12"
@@ -5085,10 +5314,10 @@
       }
     },
     "node_modules/@sanity/export/node_modules/lru-cache": {
-      "version": "11.2.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.2.tgz",
-      "integrity": "sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==",
-      "license": "ISC",
+      "version": "11.2.4",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.4.tgz",
+      "integrity": "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==",
+      "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
       }
@@ -5144,9 +5373,9 @@
       }
     },
     "node_modules/@sanity/generate-help-url": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@sanity/generate-help-url/-/generate-help-url-3.0.0.tgz",
-      "integrity": "sha512-wtMYcV5GIDIhVyF/jjmdwq1GdlK07dRL40XMns73VbrFI7FteRltxv48bhYVZPcLkRXb0SHjpDS/icj9/yzbVA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sanity/generate-help-url/-/generate-help-url-3.0.1.tgz",
+      "integrity": "sha512-bKqCEqFP7qXpNcHxJZnXFLrti8/HYQhhJtMRYFSNJ8bkUXCuUmhHKckzoyiH1n1WAZpI2Y05z2h5yZWbi3gThQ==",
       "license": "MIT"
     },
     "node_modules/@sanity/google-maps-input": {
@@ -5462,12 +5691,15 @@
       }
     },
     "node_modules/@sanity/image-url": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@sanity/image-url/-/image-url-1.2.0.tgz",
-      "integrity": "sha512-pYRhti+lDi22it+npWXkEGuYyzbXJLF+d0TYLiyWbKu46JHhYhTDKkp6zmGu4YKF5cXUjT6pnUjFsaf2vlB9nQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@sanity/image-url/-/image-url-2.0.2.tgz",
+      "integrity": "sha512-JnwFIHATLXHGVTCKmVwV0xy3xKwGlgVfeUB9cWxu72xJZMsQUyFgGiTz4zD9gRXuncAndkmtzHeIG+2vhKgxHA==",
       "license": "MIT",
+      "dependencies": {
+        "@sanity/signed-urls": "^2.0.1"
+      },
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@sanity/import": {
@@ -5532,10 +5764,10 @@
       }
     },
     "node_modules/@sanity/import/node_modules/lru-cache": {
-      "version": "11.2.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.2.tgz",
-      "integrity": "sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==",
-      "license": "ISC",
+      "version": "11.2.4",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.4.tgz",
+      "integrity": "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==",
+      "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
       }
@@ -5928,31 +6160,31 @@
       "license": "MIT"
     },
     "node_modules/@sanity/message-protocol": {
-      "version": "0.17.6",
-      "resolved": "https://registry.npmjs.org/@sanity/message-protocol/-/message-protocol-0.17.6.tgz",
-      "integrity": "sha512-rd5TG0TsXqwcmOapjHQJTLhB51NuNgbDJME9vDM9ezD1D7ZA3kEotFVAij+rS5L5C/VWxTxXusaMXa8pp8p+lA==",
+      "version": "0.17.8",
+      "resolved": "https://registry.npmjs.org/@sanity/message-protocol/-/message-protocol-0.17.8.tgz",
+      "integrity": "sha512-bx/NvakGt7Pm1JcHGzL5GVnPINa3XLd/YPF5JNo3NOO/yZiHMYM54+HK0u98ECZTLhlDe7+ALtok+lyQh3S+3g==",
       "license": "MIT",
       "dependencies": {
-        "@sanity/comlink": "^4.0.0"
+        "@sanity/comlink": "^4.0.1"
       },
       "engines": {
         "node": ">=20.0.0"
       }
     },
     "node_modules/@sanity/migrate": {
-      "version": "4.19.0",
-      "resolved": "https://registry.npmjs.org/@sanity/migrate/-/migrate-4.19.0.tgz",
-      "integrity": "sha512-y8UtICYpH9YyDoj+8eV+wZSp5sjWsX+384Ozp71fD6V78MQpNN1NazGOmnERJMS/TRjuwW3ouoyCdx/OeqpKDA==",
+      "version": "4.21.1",
+      "resolved": "https://registry.npmjs.org/@sanity/migrate/-/migrate-4.21.1.tgz",
+      "integrity": "sha512-tcQ4AN8d8Ln7ycof0jYKS2PhETlFfhXwBPTthGeMwarrY4COqP1Fh8tLA5bN/M9+4kVPkMJpPr3yqMlx+XKd7A==",
       "license": "MIT",
       "dependencies": {
-        "@sanity/client": "^7.12.1",
-        "@sanity/mutate": "^0.14.0",
-        "@sanity/types": "4.19.0",
-        "@sanity/util": "4.19.0",
+        "@sanity/client": "^7.13.2",
+        "@sanity/mutate": "^0.15.0",
+        "@sanity/types": "4.21.1",
+        "@sanity/util": "4.21.1",
         "arrify": "^2.0.1",
         "debug": "^4.4.3",
         "fast-fifo": "^1.3.2",
-        "groq-js": "^1.21.0",
+        "groq-js": "^1.23.0",
         "p-map": "^7.0.1"
       },
       "engines": {
@@ -5960,12 +6192,12 @@
       }
     },
     "node_modules/@sanity/migrate/node_modules/@sanity/types": {
-      "version": "4.19.0",
-      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-4.19.0.tgz",
-      "integrity": "sha512-i6o1HREiaccZgMXOj04wuB7Qk9CS79JIA+CSxKxVwDu7UCsNyRtExjVYTlNIA8SkOP/S2ZdPpJOf8uXFsIrXtQ==",
+      "version": "4.21.1",
+      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-4.21.1.tgz",
+      "integrity": "sha512-v0xoriwlg6wtYMIWMy7i6VBfke/Sts/sikwW2Sd+tG55jPGBk25B9N0oymn2YsT6fFsypsP5RqIyByWYSX5lWA==",
       "license": "MIT",
       "dependencies": {
-        "@sanity/client": "^7.12.1",
+        "@sanity/client": "^7.13.2",
         "@sanity/media-library-types": "^1.0.1"
       },
       "peerDependencies": {
@@ -5973,9 +6205,9 @@
       }
     },
     "node_modules/@sanity/mutate": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@sanity/mutate/-/mutate-0.14.0.tgz",
-      "integrity": "sha512-KQuCY/NgCgaBywopcbPaJWgCb6wAa0AjabdPyQm0ndp5pgu9H8umj59ulHO0WBE85cswTGRmkzQH73a6FKUNFw==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@sanity/mutate/-/mutate-0.15.0.tgz",
+      "integrity": "sha512-q91tzqOoGguLm0BSoCCKAbVSQNtQE/agGHWD31v1e2uh3E2fEZ1cPcAUsQVlTXc1nvuP86QX5A8/P6QR9Gpt6g==",
       "license": "MIT",
       "dependencies": {
         "@sanity/client": "^7.9.0",
@@ -6061,13 +6293,14 @@
       }
     },
     "node_modules/@sanity/runtime-cli": {
-      "version": "11.1.5",
-      "resolved": "https://registry.npmjs.org/@sanity/runtime-cli/-/runtime-cli-11.1.5.tgz",
-      "integrity": "sha512-ma/hmh0wm9oaHekO0KCJRk1mPAcI8Ja7YiqngSU0sjQ1rI30e7Oo1WOj+zYWRwt2azbkLbAmQh4A0J7ir4/8wg==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@sanity/runtime-cli/-/runtime-cli-12.1.0.tgz",
+      "integrity": "sha512-Q4odwwUpbR0QD9rVOqOq6nmQtRgeSwQscpkrqtB6vEmCvu1uJL3DLB4PjgQFCCLUdlLGg0IHfG8cQmkm4H6zag==",
       "license": "MIT",
       "dependencies": {
-        "@architect/hydrate": "^4.0.10",
-        "@architect/inventory": "^4.0.9",
+        "@architect/hydrate": "^5.0.1",
+        "@architect/inventory": "^5.0.0",
+        "@inquirer/prompts": "^8.0.1",
         "@oclif/core": "^4.8.0",
         "@oclif/plugin-help": "^6.2.36",
         "@sanity/blueprints-parser": "^0.3.0",
@@ -6303,18 +6536,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@sanity/runtime-cli/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/@sanity/runtime-cli/node_modules/string-width": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.1.0.tgz",
@@ -6344,16 +6565,16 @@
       }
     },
     "node_modules/@sanity/schema": {
-      "version": "4.19.0",
-      "resolved": "https://registry.npmjs.org/@sanity/schema/-/schema-4.19.0.tgz",
-      "integrity": "sha512-Kmf4FZw1BVqWqMlLtTFptOOGmM6l//SormkXQax8hmHgd6rTC9zUuaBgybcUgW4FzYUUCMTGKtVV9aFJuDdtsQ==",
+      "version": "4.21.1",
+      "resolved": "https://registry.npmjs.org/@sanity/schema/-/schema-4.21.1.tgz",
+      "integrity": "sha512-7+JTAXlF0VTTBqfGTyWsAI/65BGuMjqgXxPBgPnbZ8a0FSzutM3gP++m5MbaEnLY7W5z5+NzjBQuSIak8GvqJg==",
       "license": "MIT",
       "dependencies": {
-        "@sanity/descriptors": "^1.1.1",
-        "@sanity/generate-help-url": "^3.0.0",
-        "@sanity/types": "4.19.0",
+        "@sanity/descriptors": "^1.2.1",
+        "@sanity/generate-help-url": "^3.0.1",
+        "@sanity/types": "4.21.1",
         "arrify": "^2.0.1",
-        "groq-js": "^1.21.0",
+        "groq-js": "^1.23.0",
         "humanize-list": "^1.0.1",
         "leven": "^3.1.0",
         "lodash": "^4.17.21",
@@ -6361,12 +6582,12 @@
       }
     },
     "node_modules/@sanity/schema/node_modules/@sanity/types": {
-      "version": "4.19.0",
-      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-4.19.0.tgz",
-      "integrity": "sha512-i6o1HREiaccZgMXOj04wuB7Qk9CS79JIA+CSxKxVwDu7UCsNyRtExjVYTlNIA8SkOP/S2ZdPpJOf8uXFsIrXtQ==",
+      "version": "4.21.1",
+      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-4.21.1.tgz",
+      "integrity": "sha512-v0xoriwlg6wtYMIWMy7i6VBfke/Sts/sikwW2Sd+tG55jPGBk25B9N0oymn2YsT6fFsypsP5RqIyByWYSX5lWA==",
       "license": "MIT",
       "dependencies": {
-        "@sanity/client": "^7.12.1",
+        "@sanity/client": "^7.13.2",
         "@sanity/media-library-types": "^1.0.1"
       },
       "peerDependencies": {
@@ -6509,6 +6730,16 @@
         "uuid": "dist/esm/bin/uuid"
       }
     },
+    "node_modules/@sanity/signed-urls": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@sanity/signed-urls/-/signed-urls-2.0.1.tgz",
+      "integrity": "sha512-/u++FnDbaXDWHiHxG1Q4rbGsKRPf6lmTKsXeZ3bbbty/kNHDhVRUA5mRA+TtXlbPrse4ksv3a2vAerKNUNDZOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/ed25519": "^3.0.0",
+        "@noble/hashes": "^2.0.0"
+      }
+    },
     "node_modules/@sanity/studio-secrets": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@sanity/studio-secrets/-/studio-secrets-3.0.2.tgz",
@@ -6603,15 +6834,15 @@
       }
     },
     "node_modules/@sanity/util": {
-      "version": "4.19.0",
-      "resolved": "https://registry.npmjs.org/@sanity/util/-/util-4.19.0.tgz",
-      "integrity": "sha512-CTkRQBEDpHwubz58nzbimpcZvYqGXO5t25Z+ohdCYan4M3l5onYXtLe7xXSYJpn9swunQHznKYudlDMIU1IW0w==",
+      "version": "4.21.1",
+      "resolved": "https://registry.npmjs.org/@sanity/util/-/util-4.21.1.tgz",
+      "integrity": "sha512-wvMASl3Ok5I3mYuY/+W9MBEe2dC9JJh7wfs73gNuqumZJNWk3anOh1nQajHfQt9NA5kbjUPVSGZfjnL1dG/AKw==",
       "license": "MIT",
       "dependencies": {
         "@date-fns/tz": "^1.4.1",
         "@date-fns/utc": "^2.1.1",
-        "@sanity/client": "^7.12.1",
-        "@sanity/types": "4.19.0",
+        "@sanity/client": "^7.13.2",
+        "@sanity/types": "4.21.1",
         "date-fns": "^4.1.0",
         "rxjs": "^7.8.2"
       },
@@ -6620,26 +6851,16 @@
       }
     },
     "node_modules/@sanity/util/node_modules/@sanity/types": {
-      "version": "4.19.0",
-      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-4.19.0.tgz",
-      "integrity": "sha512-i6o1HREiaccZgMXOj04wuB7Qk9CS79JIA+CSxKxVwDu7UCsNyRtExjVYTlNIA8SkOP/S2ZdPpJOf8uXFsIrXtQ==",
+      "version": "4.21.1",
+      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-4.21.1.tgz",
+      "integrity": "sha512-v0xoriwlg6wtYMIWMy7i6VBfke/Sts/sikwW2Sd+tG55jPGBk25B9N0oymn2YsT6fFsypsP5RqIyByWYSX5lWA==",
       "license": "MIT",
       "dependencies": {
-        "@sanity/client": "^7.12.1",
+        "@sanity/client": "^7.13.2",
         "@sanity/media-library-types": "^1.0.1"
       },
       "peerDependencies": {
         "@types/react": "18 || 19"
-      }
-    },
-    "node_modules/@sanity/util/node_modules/date-fns": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
-      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/@sanity/uuid": {
@@ -6653,25 +6874,25 @@
       }
     },
     "node_modules/@sanity/vision": {
-      "version": "4.19.0",
-      "resolved": "https://registry.npmjs.org/@sanity/vision/-/vision-4.19.0.tgz",
-      "integrity": "sha512-k/bZJY+PNXLsA4jcVr4AiNbjE7GzgnrYgoF8FG+qZBbNEt/qqaGIhlFM82TIWtSqtK2zg2/Fag6lpVAh4u6tnw==",
+      "version": "4.21.1",
+      "resolved": "https://registry.npmjs.org/@sanity/vision/-/vision-4.21.1.tgz",
+      "integrity": "sha512-Gw9jL5e9IV1+YQbR4TZhi3EshdgNGZB8h3GqvJN/Zwo0wBGz9Mg3Us5eiSlgkjTKDRpgWnT3pv/FuX6ZY/03+w==",
       "license": "MIT",
       "dependencies": {
-        "@codemirror/autocomplete": "^6.19.1",
+        "@codemirror/autocomplete": "^6.20.0",
         "@codemirror/commands": "^6.10.0",
         "@codemirror/lang-javascript": "^6.2.4",
         "@codemirror/language": "^6.11.3",
         "@codemirror/search": "^6.5.11",
         "@codemirror/state": "^6.5.2",
-        "@codemirror/view": "^6.38.7",
+        "@codemirror/view": "^6.38.8",
         "@juggle/resize-observer": "^3.4.0",
-        "@lezer/highlight": "^1.2.1",
+        "@lezer/highlight": "^1.2.3",
         "@rexxars/react-json-inspector": "^9.0.1",
         "@rexxars/react-split-pane": "^1.0.0",
         "@sanity/color": "^3.0.6",
         "@sanity/icons": "^3.7.4",
-        "@sanity/ui": "^3.1.5",
+        "@sanity/ui": "^3.1.11",
         "@sanity/uuid": "^3.0.2",
         "@uiw/react-codemirror": "^4.25.1",
         "is-hotkey-esm": "^1.0.0",
@@ -7088,12 +7309,12 @@
       }
     },
     "node_modules/@tanstack/react-virtual": {
-      "version": "3.13.12",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.12.tgz",
-      "integrity": "sha512-Gd13QdxPSukP8ZrkbgS2RwoZseTTbQPLnQEn7HY/rqtM+8Zt95f7xKC7N0EsKs7aoz0WzZ+fditZux+F8EzYxA==",
+      "version": "3.13.13",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.13.tgz",
+      "integrity": "sha512-4o6oPMDvQv+9gMi8rE6gWmsOjtUZUYIJHv7EB+GblyYdi8U6OqLl8rhHWIUZSL1dUU2dPwTdTgybCKf9EjIrQg==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/virtual-core": "3.13.12"
+        "@tanstack/virtual-core": "3.13.13"
       },
       "funding": {
         "type": "github",
@@ -7118,9 +7339,9 @@
       }
     },
     "node_modules/@tanstack/virtual-core": {
-      "version": "3.13.12",
-      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.12.tgz",
-      "integrity": "sha512-1YBOJfRHV4sXUmWsFSf5rQor4Ss82G8dQWLRbnk3GA4jeP8hQt1hxXh0tmflpC0dz3VgEv/1+qwPyLeWkQuPFA==",
+      "version": "3.13.13",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.13.tgz",
+      "integrity": "sha512-uQFoSdKKf5S8k51W5t7b2qpfkyIbdHMzAn+AMQvHPxKUPeo1SsGaA4JRISQT87jm28b7z8OEqPcg1IOZagQHcA==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -7231,9 +7452,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.10.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.1.tgz",
-      "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
+      "version": "25.0.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.0.tgz",
+      "integrity": "sha512-rl78HwuZlaDIUSeUKkmogkhebA+8K1Hy7tddZuJ3D0xV8pZSfsYGTsliGUol1JPzu9EKnTxPC4L1fiWouStRew==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -7342,18 +7563,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.48.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.48.0.tgz",
-      "integrity": "sha512-XxXP5tL1txl13YFtrECECQYeZjBZad4fyd3cFV4a19LkAY/bIp9fev3US4S5fDVV2JaYFiKAZ/GRTOLer+mbyQ==",
+      "version": "8.49.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.49.0.tgz",
+      "integrity": "sha512-JXij0vzIaTtCwu6SxTh8qBc66kmf1xs7pI4UOiMDFVct6q86G0Zs7KRcEoJgY3Cav3x5Tq0MF5jwgpgLqgKG3A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.48.0",
-        "@typescript-eslint/type-utils": "8.48.0",
-        "@typescript-eslint/utils": "8.48.0",
-        "@typescript-eslint/visitor-keys": "8.48.0",
-        "graphemer": "^1.4.0",
+        "@typescript-eslint/scope-manager": "8.49.0",
+        "@typescript-eslint/type-utils": "8.49.0",
+        "@typescript-eslint/utils": "8.49.0",
+        "@typescript-eslint/visitor-keys": "8.49.0",
         "ignore": "^7.0.0",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.1.0"
@@ -7366,7 +7586,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.48.0",
+        "@typescript-eslint/parser": "^8.49.0",
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
@@ -7382,17 +7602,17 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.48.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.48.0.tgz",
-      "integrity": "sha512-jCzKdm/QK0Kg4V4IK/oMlRZlY+QOcdjv89U2NgKHZk1CYTj82/RVSx1mV/0gqCVMJ/DA+Zf/S4NBWNF8GQ+eqQ==",
+      "version": "8.49.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.49.0.tgz",
+      "integrity": "sha512-N9lBGA9o9aqb1hVMc9hzySbhKibHmB+N3IpoShyV6HyQYRGIhlrO5rQgttypi+yEeKsKI4idxC8Jw6gXKD4THA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.48.0",
-        "@typescript-eslint/types": "8.48.0",
-        "@typescript-eslint/typescript-estree": "8.48.0",
-        "@typescript-eslint/visitor-keys": "8.48.0",
+        "@typescript-eslint/scope-manager": "8.49.0",
+        "@typescript-eslint/types": "8.49.0",
+        "@typescript-eslint/typescript-estree": "8.49.0",
+        "@typescript-eslint/visitor-keys": "8.49.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -7408,14 +7628,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.48.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.48.0.tgz",
-      "integrity": "sha512-Ne4CTZyRh1BecBf84siv42wv5vQvVmgtk8AuiEffKTUo3DrBaGYZueJSxxBZ8fjk/N3DrgChH4TOdIOwOwiqqw==",
+      "version": "8.49.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.49.0.tgz",
+      "integrity": "sha512-/wJN0/DKkmRUMXjZUXYZpD1NEQzQAAn9QWfGwo+Ai8gnzqH7tvqS7oNVdTjKqOcPyVIdZdyCMoqN66Ia789e7g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.48.0",
-        "@typescript-eslint/types": "^8.48.0",
+        "@typescript-eslint/tsconfig-utils": "^8.49.0",
+        "@typescript-eslint/types": "^8.49.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -7430,14 +7650,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.48.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.48.0.tgz",
-      "integrity": "sha512-uGSSsbrtJrLduti0Q1Q9+BF1/iFKaxGoQwjWOIVNJv0o6omrdyR8ct37m4xIl5Zzpkp69Kkmvom7QFTtue89YQ==",
+      "version": "8.49.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.49.0.tgz",
+      "integrity": "sha512-npgS3zi+/30KSOkXNs0LQXtsg9ekZ8OISAOLGWA/ZOEn0ZH74Ginfl7foziV8DT+D98WfQ5Kopwqb/PZOaIJGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.48.0",
-        "@typescript-eslint/visitor-keys": "8.48.0"
+        "@typescript-eslint/types": "8.49.0",
+        "@typescript-eslint/visitor-keys": "8.49.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -7448,9 +7668,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.48.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.48.0.tgz",
-      "integrity": "sha512-WNebjBdFdyu10sR1M4OXTt2OkMd5KWIL+LLfeH9KhgP+jzfDV/LI3eXzwJ1s9+Yc0Kzo2fQCdY/OpdusCMmh6w==",
+      "version": "8.49.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.49.0.tgz",
+      "integrity": "sha512-8prixNi1/6nawsRYxet4YOhnbW+W9FK/bQPxsGB1D3ZrDzbJ5FXw5XmzxZv82X3B+ZccuSxo/X8q9nQ+mFecWA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7465,15 +7685,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.48.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.48.0.tgz",
-      "integrity": "sha512-zbeVaVqeXhhab6QNEKfK96Xyc7UQuoFWERhEnj3mLVnUWrQnv15cJNseUni7f3g557gm0e46LZ6IJ4NJVOgOpw==",
+      "version": "8.49.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.49.0.tgz",
+      "integrity": "sha512-KTExJfQ+svY8I10P4HdxKzWsvtVnsuCifU5MvXrRwoP2KOlNZ9ADNEWWsQTJgMxLzS5VLQKDjkCT/YzgsnqmZg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.48.0",
-        "@typescript-eslint/typescript-estree": "8.48.0",
-        "@typescript-eslint/utils": "8.48.0",
+        "@typescript-eslint/types": "8.49.0",
+        "@typescript-eslint/typescript-estree": "8.49.0",
+        "@typescript-eslint/utils": "8.49.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^2.1.0"
       },
@@ -7490,9 +7710,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.48.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.48.0.tgz",
-      "integrity": "sha512-cQMcGQQH7kwKoVswD1xdOytxQR60MWKM1di26xSUtxehaDs/32Zpqsu5WJlXTtTTqyAVK8R7hvsUnIXRS+bjvA==",
+      "version": "8.49.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.49.0.tgz",
+      "integrity": "sha512-e9k/fneezorUo6WShlQpMxXh8/8wfyc+biu6tnAqA81oWrEic0k21RHzP9uqqpyBBeBKu4T+Bsjy9/b8u7obXQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7504,16 +7724,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.48.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.48.0.tgz",
-      "integrity": "sha512-ljHab1CSO4rGrQIAyizUS6UGHHCiAYhbfcIZ1zVJr5nMryxlXMVWS3duFPSKvSUbFPwkXMFk1k0EMIjub4sRRQ==",
+      "version": "8.49.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.49.0.tgz",
+      "integrity": "sha512-jrLdRuAbPfPIdYNppHJ/D0wN+wwNfJ32YTAm10eJVsFmrVpXQnDWBn8niCSMlWjvml8jsce5E/O+86IQtTbJWA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.48.0",
-        "@typescript-eslint/tsconfig-utils": "8.48.0",
-        "@typescript-eslint/types": "8.48.0",
-        "@typescript-eslint/visitor-keys": "8.48.0",
+        "@typescript-eslint/project-service": "8.49.0",
+        "@typescript-eslint/tsconfig-utils": "8.49.0",
+        "@typescript-eslint/types": "8.49.0",
+        "@typescript-eslint/visitor-keys": "8.49.0",
         "debug": "^4.3.4",
         "minimatch": "^9.0.4",
         "semver": "^7.6.0",
@@ -7571,16 +7791,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.48.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.48.0.tgz",
-      "integrity": "sha512-yTJO1XuGxCsSfIVt1+1UrLHtue8xz16V8apzPYI06W0HbEbEWHxHXgZaAgavIkoh+GeV6hKKd5jm0sS6OYxWXQ==",
+      "version": "8.49.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.49.0.tgz",
+      "integrity": "sha512-N3W7rJw7Rw+z1tRsHZbK395TWSYvufBXumYtEGzypgMUthlg0/hmCImeA8hgO2d2G4pd7ftpxxul2J8OdtdaFA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.7.0",
-        "@typescript-eslint/scope-manager": "8.48.0",
-        "@typescript-eslint/types": "8.48.0",
-        "@typescript-eslint/typescript-estree": "8.48.0"
+        "@typescript-eslint/scope-manager": "8.49.0",
+        "@typescript-eslint/types": "8.49.0",
+        "@typescript-eslint/typescript-estree": "8.49.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -7595,13 +7815,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.48.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.48.0.tgz",
-      "integrity": "sha512-T0XJMaRPOH3+LBbAfzR2jalckP1MSG/L9eUtY0DEzUyVaXJ/t6zN0nR7co5kz0Jko/nkSYCBRkz1djvjajVTTg==",
+      "version": "8.49.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.49.0.tgz",
+      "integrity": "sha512-LlKaciDe3GmZFphXIc79THF/YYBugZ7FS1pO581E/edlVVNbZKDy93evqmrfQ9/Y4uN0vVhX4iuchq26mK/iiA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.48.0",
+        "@typescript-eslint/types": "8.49.0",
         "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
@@ -7672,20 +7892,20 @@
       "license": "Apache-2.0"
     },
     "node_modules/@vitejs/plugin-react": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
-      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.1.2.tgz",
+      "integrity": "sha512-EcA07pHJouywpzsoTUqNh5NwGayl2PPVEJKUSinGGSxFGYn+shYbqMGBg6FXDqgXum9Ou/ecb+411ssw8HImJQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/core": "^7.28.0",
+        "@babel/core": "^7.28.5",
         "@babel/plugin-transform-react-jsx-self": "^7.27.1",
         "@babel/plugin-transform-react-jsx-source": "^7.27.1",
-        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@rolldown/pluginutils": "1.0.0-beta.53",
         "@types/babel__core": "^7.20.5",
-        "react-refresh": "^0.17.0"
+        "react-refresh": "^0.18.0"
       },
       "engines": {
-        "node": "^14.18.0 || >=16.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
@@ -7746,12 +7966,12 @@
       }
     },
     "node_modules/acorn-loose": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/acorn-loose/-/acorn-loose-8.4.0.tgz",
-      "integrity": "sha512-M0EUka6rb+QC4l9Z3T0nJEzNOO7JcoJlYMrBlyBCiFSXRyxjLKayd4TbQs2FDRWQU1h9FR7QVNHt+PEaoNL5rQ==",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/acorn-loose/-/acorn-loose-8.5.2.tgz",
+      "integrity": "sha512-PPvV6g8UGMGgjrMu+n/f9E/tCSkNQ2Y97eFvuVdJfG11+xdIeDcLyNdC8SHcrHbRqkfwLASdplyR6B6sKM1U4A==",
       "license": "MIT",
       "dependencies": {
-        "acorn": "^8.11.0"
+        "acorn": "^8.15.0"
       },
       "engines": {
         "node": ">=0.4.0"
@@ -7902,7 +8122,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/aria-query": {
@@ -8251,9 +8470,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.8.31",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.31.tgz",
-      "integrity": "sha512-a28v2eWrrRWPpJSzxc+mKwm0ZtVx/G8SepdQZDArnXYU/XS+IF6mp8aB/4E+hH1tyGCoDo3KlUCdlSxGDsRkAw==",
+      "version": "2.9.6",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.6.tgz",
+      "integrity": "sha512-v9BVVpOTLB59C9E7aSnmIF8h7qRsFpx+A2nugVMTszEOMcfjlZMsXRm4LF23I3Z9AJxc8ANpIvzbzONoX9VJlg==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
@@ -8350,9 +8569,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.0.tgz",
-      "integrity": "sha512-tbydkR/CxfMwelN0vwdP/pLkDwyAASZ+VfWm4EOwlB6SWhx1sYnWLqo8N5j0rAzPfzfRaxt0mM/4wPU/Su84RQ==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
+      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
       "funding": [
         {
           "type": "opencollective",
@@ -8370,11 +8589,11 @@
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "baseline-browser-mapping": "^2.8.25",
-        "caniuse-lite": "^1.0.30001754",
-        "electron-to-chromium": "^1.5.249",
+        "baseline-browser-mapping": "^2.9.0",
+        "caniuse-lite": "^1.0.30001759",
+        "electron-to-chromium": "^1.5.263",
         "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.1.4"
+        "update-browserslist-db": "^1.2.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -8525,9 +8744,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001757",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001757.tgz",
-      "integrity": "sha512-r0nnL/I28Zi/yjk1el6ilj27tKcdjLsNqAOZr0yVjWPrSQyHgKI2INaEWw21bAQSv2LXRt1XuCS/GomNpWOxsQ==",
+      "version": "1.0.30001760",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001760.tgz",
+      "integrity": "sha512-7AAMPcueWELt1p3mi13HR/LHH0TJLT11cnwDJEs3xA4+CK/PLKeO9Kl1oru24htkyUKtkGCvAx4ohB0Ttry8Dw==",
       "funding": [
         {
           "type": "opencollective",
@@ -8664,13 +8883,10 @@
       }
     },
     "node_modules/chownr": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
-      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
-      }
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
     },
     "node_modules/classnames": {
       "version": "2.5.1",
@@ -8759,6 +8975,23 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/clone": {
@@ -8907,6 +9140,16 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/config-chain": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+      "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ini": "^1.3.4",
+        "proto-list": "~1.2.1"
       }
     },
     "node_modules/configstore": {
@@ -9217,19 +9460,13 @@
       "license": "MIT"
     },
     "node_modules/date-fns": {
-      "version": "2.30.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
-      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
       "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.21.0"
-      },
-      "engines": {
-        "node": ">=0.11"
-      },
       "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/date-fns"
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debounce": {
@@ -9340,6 +9577,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 16"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/deep-is": {
@@ -9516,9 +9762,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.0.tgz",
-      "integrity": "sha512-r+f6MYR1gGN1eJv0TVQbhA7if/U7P87cdPl3HN5rikqaBSBxLiCb/b9O+2eG0cxz0ghyU+mU1QkbsOwERMYlWQ==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.1.tgz",
+      "integrity": "sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -9621,9 +9867,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.262",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.262.tgz",
-      "integrity": "sha512-NlAsMteRHek05jRUxUR0a5jpjYq9ykk6+kO0yRaMi5moe7u0fVIOeQ3Y30A8dIiWFBNUoQGi1ljb1i5VtS9WQQ==",
+      "version": "1.5.267",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.267.tgz",
+      "integrity": "sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -10166,6 +10412,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
     "node_modules/events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -10221,6 +10473,12 @@
       "engines": {
         "node": "^8.12.0 || >=9.7.0"
       }
+    },
+    "node_modules/execa/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
     },
     "node_modules/exif-component": {
       "version": "1.0.1",
@@ -10665,18 +10923,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/foreground-child/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/form-data": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
@@ -10715,9 +10961,9 @@
       }
     },
     "node_modules/framer-motion": {
-      "version": "12.23.24",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.23.24.tgz",
-      "integrity": "sha512-HMi5HRoRCTou+3fb3h9oTLyJGBxHfW+HnNE25tAXOvVx/IvwMHK0cx7IR4a2ZU6sh3IX1Z+4ts32PcYBOqka8w==",
+      "version": "12.23.26",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.23.26.tgz",
+      "integrity": "sha512-cPcIhgR42xBn1Uj+PzOyheMtZ73H927+uWPDVhUMqxy8UHt6Okavb6xIz9J/phFUHUj0OncR6UvMfJTXoc/LKA==",
       "license": "MIT",
       "dependencies": {
         "motion-dom": "^12.23.23",
@@ -10960,9 +11206,9 @@
       }
     },
     "node_modules/get-it": {
-      "version": "8.6.10",
-      "resolved": "https://registry.npmjs.org/get-it/-/get-it-8.6.10.tgz",
-      "integrity": "sha512-27StIK860ZVp2bhsG/aTWpcoA4OrFxtMqBbesa5sR23m5OxfVQYCnpm2rPQeo3gs5qsUk0FdkISLgXRJ4HynNw==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/get-it/-/get-it-8.7.0.tgz",
+      "integrity": "sha512-uong/+jOz0GiuIWIUJXp2tnQKgQKukC99LEqOxLckPUoHYoerQbV6vC0Tu+/pSgk0tgHh1xX2aJtCk4y35LLLg==",
       "license": "MIT",
       "dependencies": {
         "@types/follow-redirects": "^1.14.4",
@@ -10974,6 +11220,33 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/get-latest-version": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/get-latest-version/-/get-latest-version-5.1.0.tgz",
+      "integrity": "sha512-Q6IBWr/zzw57zIkJmNhI23eRTw3nZ4BWWK034meLwOYU9L3J3IpXiyM73u2pYUwN6U7ahkerCwg2T0jlxiLwsw==",
+      "license": "MIT",
+      "dependencies": {
+        "get-it": "^8.0.9",
+        "registry-auth-token": "^5.0.2",
+        "registry-url": "^5.1.0",
+        "semver": "^7.3.8"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/get-latest-version/node_modules/semver": {
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/get-package-type": {
@@ -11097,9 +11370,9 @@
       }
     },
     "node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
       "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
@@ -11227,26 +11500,19 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
     },
-    "node_modules/graphemer": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
-      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/groq": {
-      "version": "4.19.0",
-      "resolved": "https://registry.npmjs.org/groq/-/groq-4.19.0.tgz",
-      "integrity": "sha512-5BKaBYoJg4yhjd2CkZeRtAl4xh43kSCH4gRt3T2WSenDdWwOJa4J8S8xfbL9Bl1BK+QEKp/p5HUIwF0onbcNqw==",
+      "version": "4.21.1",
+      "resolved": "https://registry.npmjs.org/groq/-/groq-4.21.1.tgz",
+      "integrity": "sha512-9+4WEkxsOYTJFzXp3JT3gD2cgQIqI+whs/rYfxoUI4WDE3lIugtFiKmX1WMQhTvddOCx8rnOyXbDwiBVGMWmwg==",
       "license": "MIT",
       "engines": {
         "node": ">=20.19 <22 || >=22.12"
       }
     },
     "node_modules/groq-js": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/groq-js/-/groq-js-1.21.0.tgz",
-      "integrity": "sha512-CQlUzcD5Ju30P+yEuxYJzQjwjC1w5OyZ207ZVKOAdwvVTGGOKM7QPa8nGGEsrEVNM0fQ7VyRC39WGecqRmDJLg==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/groq-js/-/groq-js-1.23.0.tgz",
+      "integrity": "sha512-5NAIMuK8BYLbgvBPimnh+KZOSqp+09gSrtn0kYtstOFNF6lN77bPKHezdJDRRLQvfbR/RWJ7B0ygtG/KbMX90g==",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4"
@@ -11597,9 +11863,9 @@
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
-      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.1.tgz",
+      "integrity": "sha512-2Tth85cXwGFHfvRgZWszZSvdo+0Xsqmw8k8ZwxScfcBneNUraK+dxRxRm24nszx80Y0TVio8kKLt5sLE7ZCLlw==",
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -11639,17 +11905,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
-      }
-    },
-    "node_modules/immer": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-11.0.1.tgz",
-      "integrity": "sha512-naDCyggtcBWANtIrjQEajhhBEuL9b0Zg4zmlWK2CzS6xCWSE39/vvf4LqnMjUAWHBhot4m9MHCM/Z+mfWhUkiA==",
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/immer"
       }
     },
     "node_modules/import-fresh": {
@@ -11692,6 +11947,12 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
+    },
     "node_modules/inquirer": {
       "version": "12.11.1",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-12.11.1.tgz",
@@ -11716,6 +11977,384 @@
         "@types/node": {
           "optional": true
         }
+      }
+    },
+    "node_modules/inquirer/node_modules/@inquirer/ansi": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.2.tgz",
+      "integrity": "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/inquirer/node_modules/@inquirer/checkbox": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.3.2.tgz",
+      "integrity": "sha512-VXukHf0RR1doGe6Sm4F0Em7SWYLTHSsbGfJdS9Ja2bX5/D5uwVOEjr07cncLROdBvmnvCATYEWlHqYmXv2IlQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/inquirer/node_modules/@inquirer/confirm": {
+      "version": "5.1.21",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.21.tgz",
+      "integrity": "sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/inquirer/node_modules/@inquirer/core": {
+      "version": "10.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.3.2.tgz",
+      "integrity": "sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "cli-width": "^4.1.0",
+        "mute-stream": "^2.0.0",
+        "signal-exit": "^4.1.0",
+        "wrap-ansi": "^6.2.0",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/inquirer/node_modules/@inquirer/editor": {
+      "version": "4.2.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.23.tgz",
+      "integrity": "sha512-aLSROkEwirotxZ1pBaP8tugXRFCxW94gwrQLxXfrZsKkfjOYC1aRvAZuhpJOb5cu4IBTJdsCigUlf2iCOu4ZDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/external-editor": "^1.0.3",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/inquirer/node_modules/@inquirer/expand": {
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.23.tgz",
+      "integrity": "sha512-nRzdOyFYnpeYTTR2qFwEVmIWypzdAx/sIkCMeTNTcflFOovfqUk+HcFhQQVBftAh9gmGrpFj6QcGEqrDMDOiew==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/inquirer/node_modules/@inquirer/external-editor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz",
+      "integrity": "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==",
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^2.1.1",
+        "iconv-lite": "^0.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/inquirer/node_modules/@inquirer/figures": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.15.tgz",
+      "integrity": "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/inquirer/node_modules/@inquirer/input": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.3.1.tgz",
+      "integrity": "sha512-kN0pAM4yPrLjJ1XJBjDxyfDduXOuQHrBB8aLDMueuwUGn+vNpF7Gq7TvyVxx8u4SHlFFj4trmj+a2cbpG4Jn1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/inquirer/node_modules/@inquirer/number": {
+      "version": "3.0.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.23.tgz",
+      "integrity": "sha512-5Smv0OK7K0KUzUfYUXDXQc9jrf8OHo4ktlEayFlelCjwMXz0299Y8OrI+lj7i4gCBY15UObk76q0QtxjzFcFcg==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/inquirer/node_modules/@inquirer/password": {
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.23.tgz",
+      "integrity": "sha512-zREJHjhT5vJBMZX/IUbyI9zVtVfOLiTO66MrF/3GFZYZ7T4YILW5MSkEYHceSii/KtRk+4i3RE7E1CUXA2jHcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/inquirer/node_modules/@inquirer/prompts": {
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.10.1.tgz",
+      "integrity": "sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/checkbox": "^4.3.2",
+        "@inquirer/confirm": "^5.1.21",
+        "@inquirer/editor": "^4.2.23",
+        "@inquirer/expand": "^4.0.23",
+        "@inquirer/input": "^4.3.1",
+        "@inquirer/number": "^3.0.23",
+        "@inquirer/password": "^4.0.23",
+        "@inquirer/rawlist": "^4.1.11",
+        "@inquirer/search": "^3.2.2",
+        "@inquirer/select": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/inquirer/node_modules/@inquirer/rawlist": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.1.11.tgz",
+      "integrity": "sha512-+LLQB8XGr3I5LZN/GuAHo+GpDJegQwuPARLChlMICNdwW7OwV2izlCSCxN6cqpL0sMXmbKbFcItJgdQq5EBXTw==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/inquirer/node_modules/@inquirer/search": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.2.2.tgz",
+      "integrity": "sha512-p2bvRfENXCZdWF/U2BXvnSI9h+tuA8iNqtUKb9UWbmLYCRQxd8WkvwWvYn+3NgYaNwdUkHytJMGG4MMLucI1kA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/inquirer/node_modules/@inquirer/select": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.4.2.tgz",
+      "integrity": "sha512-l4xMuJo55MAe+N7Qr4rX90vypFwCajSakx59qe/tMaC1aEHWLyw68wF4o0A4SLAY4E0nd+Vt+EyskeDIqu1M6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/inquirer/node_modules/@inquirer/type": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.10.tgz",
+      "integrity": "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/inquirer/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/inquirer/node_modules/mute-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
+      "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/inquirer/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/inquirer/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/internal-slot": {
@@ -12365,13 +13004,13 @@
       }
     },
     "node_modules/isomorphic-dompurify": {
-      "version": "2.33.0",
-      "resolved": "https://registry.npmjs.org/isomorphic-dompurify/-/isomorphic-dompurify-2.33.0.tgz",
-      "integrity": "sha512-pXGR3rAHAXb5Bvr56pc5aV0Lh8laubLo7/60F+soOzDFmwks6MtgDhL7p46VoxLnwgIsjgmVhQpUt4mUlL/XEw==",
+      "version": "2.34.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-dompurify/-/isomorphic-dompurify-2.34.0.tgz",
+      "integrity": "sha512-7VeB/tDBQ8jt1+syT563hmmejY01nuwizpUIFPfM1aw3iTgLLiVP4/Nh+PKhNoa1V/H+E6ZlNcowsXLbChPCpw==",
       "license": "MIT",
       "dependencies": {
-        "dompurify": "^3.3.0",
-        "jsdom": "^27.2.0"
+        "dompurify": "^3.3.1",
+        "jsdom": "^27.3.0"
       },
       "engines": {
         "node": ">=20.19.5"
@@ -12391,13 +13030,13 @@
       }
     },
     "node_modules/isomorphic-dompurify/node_modules/cssstyle": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.3.tgz",
-      "integrity": "sha512-OytmFH+13/QXONJcC75QNdMtKpceNk3u8ThBjyyYjkEcy/ekBwR1mMAuNvi3gdBPW3N5TlCzQ0WZw8H0lN/bDw==",
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.4.tgz",
+      "integrity": "sha512-KyOS/kJMEq5O9GdPnaf82noigg5X5DYn0kZPJTaAsCUaBizp6Xa1y9D4Qoqf/JazEXWuruErHgVXwjN5391ZJw==",
       "license": "MIT",
       "dependencies": {
-        "@asamuzakjp/css-color": "^4.0.3",
-        "@csstools/css-syntax-patches-for-csstree": "^1.0.14",
+        "@asamuzakjp/css-color": "^4.1.0",
+        "@csstools/css-syntax-patches-for-csstree": "1.0.14",
         "css-tree": "^3.1.0"
       },
       "engines": {
@@ -12430,14 +13069,14 @@
       }
     },
     "node_modules/isomorphic-dompurify/node_modules/jsdom": {
-      "version": "27.2.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.2.0.tgz",
-      "integrity": "sha512-454TI39PeRDW1LgpyLPyURtB4Zx1tklSr6+OFOipsxGUH1WMTvk6C65JQdrj455+DP2uJ1+veBEHTGFKWVLFoA==",
+      "version": "27.3.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.3.0.tgz",
+      "integrity": "sha512-GtldT42B8+jefDUC4yUKAvsaOrH7PDHmZxZXNgF2xMmymjUbRYJvpAybZAKEmXDGTM0mCsz8duOa4vTm5AY2Kg==",
       "license": "MIT",
       "dependencies": {
-        "@acemir/cssom": "^0.9.23",
-        "@asamuzakjp/dom-selector": "^6.7.4",
-        "cssstyle": "^5.3.3",
+        "@acemir/cssom": "^0.9.28",
+        "@asamuzakjp/dom-selector": "^6.7.6",
+        "cssstyle": "^5.3.4",
         "data-urls": "^6.0.0",
         "decimal.js": "^10.6.0",
         "html-encoding-sniffer": "^4.0.0",
@@ -12469,10 +13108,10 @@
       }
     },
     "node_modules/isomorphic-dompurify/node_modules/lru-cache": {
-      "version": "11.2.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.2.tgz",
-      "integrity": "sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==",
-      "license": "ISC",
+      "version": "11.2.4",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.4.tgz",
+      "integrity": "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==",
+      "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
       }
@@ -12745,10 +13384,13 @@
       "license": "MIT"
     },
     "node_modules/json-stream-stringify": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/json-stream-stringify/-/json-stream-stringify-2.0.4.tgz",
-      "integrity": "sha512-gIPoa6K5w6j/RnQ3fOtmvICKNJGViI83A7dnTIL+0QJ/1GKuNvCPFvbFWxt0agruF4iGgDFJvge4Gua4ZoiggQ==",
-      "license": "MIT"
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/json-stream-stringify/-/json-stream-stringify-3.1.6.tgz",
+      "integrity": "sha512-x7fpwxOkbhFCaJDJ8vb1fBY3DdSa4AlITaz+HHILQJzdPMnHEFjxPwVUi1ALIbcIxDE0PNe/0i7frnY8QnBQog==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=7.10.1"
+      }
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -12915,6 +13557,15 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "license": "MIT"
     },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
     "node_modules/load-yaml-file": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/load-yaml-file/-/load-yaml-file-0.2.0.tgz",
@@ -12990,12 +13641,6 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash.startcase": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz",
-      "integrity": "sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==",
       "license": "MIT"
     },
     "node_modules/log-symbols": {
@@ -13136,6 +13781,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/markdown-it": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
+      "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -13155,6 +13817,12 @@
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
       "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
       "license": "CC0-1.0"
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "license": "MIT"
     },
     "node_modules/media-chrome": {
       "version": "4.16.1",
@@ -13367,18 +14035,6 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
-    "node_modules/minizlib": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
-      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
-      "license": "MIT",
-      "dependencies": {
-        "minipass": "^7.1.2"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
     "node_modules/mississippi": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-4.0.0.tgz",
@@ -13437,12 +14093,12 @@
       "license": "MIT"
     },
     "node_modules/motion": {
-      "version": "12.23.24",
-      "resolved": "https://registry.npmjs.org/motion/-/motion-12.23.24.tgz",
-      "integrity": "sha512-Rc5E7oe2YZ72N//S3QXGzbnXgqNrTESv8KKxABR20q2FLch9gHLo0JLyYo2hZ238bZ9Gx6cWhj9VO0IgwbMjCw==",
+      "version": "12.23.26",
+      "resolved": "https://registry.npmjs.org/motion/-/motion-12.23.26.tgz",
+      "integrity": "sha512-Ll8XhVxY8LXMVYTCfme27WH2GjBrCIzY4+ndr5QKxsK+YwCtOi2B/oBi5jcIbik5doXuWT/4KKDOVAZJkeY5VQ==",
       "license": "MIT",
       "dependencies": {
-        "framer-motion": "^12.23.24",
+        "framer-motion": "^12.23.26",
         "tslib": "^2.4.0"
       },
       "peerDependencies": {
@@ -13484,12 +14140,12 @@
       "license": "MIT"
     },
     "node_modules/mute-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
-      "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
+      "integrity": "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==",
       "license": "ISC",
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/mux-embed": {
@@ -13609,9 +14265,9 @@
       }
     },
     "node_modules/nwsapi": {
-      "version": "2.2.22",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.22.tgz",
-      "integrity": "sha512-ujSMe1OWVn55euT1ihwCI1ZcAaAU3nxUiDwfDQldc51ZXaB9m2AyOn6/jh1BLe2t/G8xd6uKG1UBF2aZJeg2SQ==",
+      "version": "2.2.23",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
+      "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
       "license": "MIT"
     },
     "node_modules/object-assign": {
@@ -13930,12 +14586,31 @@
       }
     },
     "node_modules/p-queue": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-2.4.2.tgz",
-      "integrity": "sha512-n8/y+yDJwBjoLQe1GSJbbaYQLTI7QHNZI2+rpmCDbe++WLf9HC3gf6iqj5yfPAV71W4UF3ql5W1+UBPXoXTxng==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.0.1.tgz",
+      "integrity": "sha512-RhBdVhSwJb7Ocn3e8ULk4NMwBEuOxe+1zcgphUy9c2e5aR/xbEsdVXxHJ3lynw6Qiqu7OINEyHlZkiblEpaq7w==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^5.0.1",
+        "p-timeout": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-7.0.1.tgz",
+      "integrity": "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==",
       "license": "MIT",
       "engines": {
-        "node": ">=4"
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-try": {
@@ -14132,12 +14807,6 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "license": "ISC"
-    },
-    "node_modules/path-sort": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/path-sort/-/path-sort-0.1.0.tgz",
-      "integrity": "sha512-70MSq7edKtbODYKkqXYzSMQxtYMjDgP3K6D15Fu4KUvpyBPlxDWPvv8JI9GjNDF2K5baPHFEtlg818dOmf2ifg==",
-      "license": "MIT"
     },
     "node_modules/path-to-regexp": {
       "version": "6.3.0",
@@ -14353,6 +15022,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.1.1",
@@ -14393,9 +15063,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.7.1.tgz",
-      "integrity": "sha512-RWKXE4qB3u5Z6yz7omJkjWwmTfLdcbv44jUVHC5NpfXwFGzvpQM798FGv/6WNK879tc+Cn0AAyherCl1KjbyZQ==",
+      "version": "3.7.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.7.4.tgz",
+      "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
       "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -14475,6 +15145,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/proto-list": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+      "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
+      "license": "ISC"
     },
     "node_modules/pump": {
       "version": "3.0.3",
@@ -14564,6 +15240,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -14605,10 +15290,34 @@
         "performance-now": "^2.1.0"
       }
     },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/react": {
-      "version": "19.2.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
-      "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
+      "version": "19.2.2",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.2.tgz",
+      "integrity": "sha512-BdOGOY8OKRBcgoDkwqA8Q5XvOIhoNx/Sh6BnGJlet2Abt0X5BK0BDrqGyQgLhAVjD2nAg5f6o01u/OPUhG022Q==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -14637,16 +15346,16 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
-      "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
+      "version": "19.2.2",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.2.tgz",
+      "integrity": "sha512-fhyD2BLrew6qYf4NNtHff1rLXvzR25rq49p+FeqByOazc6TcSi2n8EYulo5C1PbH+1uBW++5S1SG7FcUU6mlDg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.0"
+        "react": "^19.2.2"
       }
     },
     "node_modules/react-fast-compare": {
@@ -14656,9 +15365,9 @@
       "license": "MIT"
     },
     "node_modules/react-focus-lock": {
-      "version": "2.13.6",
-      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.13.6.tgz",
-      "integrity": "sha512-ehylFFWyYtBKXjAO9+3v8d0i+cnc1trGS0vlTGhzFW1vbFXVUTmR8s2tt/ZQG8x5hElg6rhENlLG1H3EZK0Llg==",
+      "version": "2.13.7",
+      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.13.7.tgz",
+      "integrity": "sha512-20lpZHEQrXPb+pp1tzd4ULL6DyO5D2KnR0G69tTDdydrmNhU7pdFmbQUYVyHUgp+xN29IuFR0PVuhOmvaZL9Og==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.0.0",
@@ -14705,9 +15414,9 @@
       }
     },
     "node_modules/react-is": {
-      "version": "19.2.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.0.tgz",
-      "integrity": "sha512-x3Ax3kNSMIIkyVYhWPyO09bu0uttcAIoecO/um/rKGQ4EltYWVYtyiGkS/3xMynrbVQdS69Jhlv8FXUEZehlzA==",
+      "version": "19.2.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.2.tgz",
+      "integrity": "sha512-ADrk8mxPwhyj+IB8EnMMRzxnon5hJrOdEZl+mCrrHXfPGGPYHdRm1962fvXUiWAu/ZC1G+OTgBN3Puq57iS4Yg==",
       "license": "MIT",
       "peer": true
     },
@@ -14726,9 +15435,9 @@
       }
     },
     "node_modules/react-refresh": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
-      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
+      "integrity": "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -15096,6 +15805,30 @@
         "node": ">=4"
       }
     },
+    "node_modules/registry-auth-token": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-5.1.0.tgz",
+      "integrity": "sha512-GdekYuwLXLxMuFTwAPg5UKGLW/UXzQrZvH/Zj791BQif5T05T0RsaLfHc9q3ZOKi7n+BoprPD9mJ0O0k4xzUlw==",
+      "license": "MIT",
+      "dependencies": {
+        "@pnpm/npm-conf": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/registry-url": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-5.1.0.tgz",
+      "integrity": "sha512-8acYXXTI0AkQv6RAOjE3vOaIXZkT9wo4LOFbBKYQEEnnMNBpKqdUrI6S4NT0KPIo/WVvJ5tE/X5LF/TQUf0ekw==",
+      "license": "MIT",
+      "dependencies": {
+        "rc": "^1.2.8"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/regjsgen": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.8.0.tgz",
@@ -15208,6 +15941,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/restore-cursor/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -15311,46 +16050,6 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
-    },
-    "node_modules/run-series": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/run-series/-/run-series-1.1.9.tgz",
-      "integrity": "sha512-Arc4hUN896vjkqCYrUXquBFtRZdv1PfLbTYP71efP6butxyQ0kWpiNJyAgsxscmQg1cqvHY32/UCBzXedTpU2g==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/run-waterfall": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/run-waterfall/-/run-waterfall-1.1.7.tgz",
-      "integrity": "sha512-iFPgh7SatHXOG1ClcpdwHI63geV3Hc/iL6crGSyBlH2PY7Rm/za+zoKz6FfY/Qlw5K7JwSol8pseO8fN6CMhhQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/rxjs": {
       "version": "7.8.2",
@@ -15465,12 +16164,13 @@
       "license": "MIT"
     },
     "node_modules/sanity": {
-      "version": "4.19.0",
-      "resolved": "https://registry.npmjs.org/sanity/-/sanity-4.19.0.tgz",
-      "integrity": "sha512-89wLgMGMFluD8I6Rti6y9VB9cyqWq2ptA1w0zbuRjeSIAoceTGTSPDh9fiNGRpOZ370VRDm+MA7aD0DOCJyObg==",
+      "version": "4.21.1",
+      "resolved": "https://registry.npmjs.org/sanity/-/sanity-4.21.1.tgz",
+      "integrity": "sha512-iutv4mhtgDDh7ySLx9kUkVXOW8MVyxs2WmaX4KUMEETNqV293ZrcO7PvCoRoivYE94o6v2c9cqVp8xT6ELld8w==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
+        "@date-fns/tz": "^1.4.1",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/modifiers": "^6.0.1",
         "@dnd-kit/sortable": "^7.0.2",
@@ -15478,55 +16178,55 @@
         "@isaacs/ttlcache": "^1.4.1",
         "@juggle/resize-observer": "^3.4.0",
         "@mux/mux-player-react": "^3.8.0",
-        "@portabletext/block-tools": "^4.1.1",
-        "@portabletext/editor": "^3.0.6",
-        "@portabletext/patches": "^2.0.0",
-        "@portabletext/plugin-markdown-shortcuts": "^4.0.6",
-        "@portabletext/plugin-one-line": "^3.0.6",
-        "@portabletext/plugin-typography": "^4.0.6",
-        "@portabletext/react": "^5.0.0",
-        "@portabletext/toolkit": "^4.0.0",
+        "@portabletext/block-tools": "^4.1.9",
+        "@portabletext/editor": "^3.3.5",
+        "@portabletext/patches": "^2.0.1",
+        "@portabletext/plugin-markdown-shortcuts": "^4.0.25",
+        "@portabletext/plugin-one-line": "^3.0.25",
+        "@portabletext/plugin-typography": "^4.0.25",
+        "@portabletext/react": "^6.0.0",
+        "@portabletext/toolkit": "^5.0.0",
         "@rexxars/react-json-inspector": "^9.0.1",
         "@sanity/asset-utils": "^2.3.0",
         "@sanity/bifur-client": "^0.4.1",
-        "@sanity/cli": "4.19.0",
-        "@sanity/client": "^7.12.1",
+        "@sanity/cli": "4.21.1",
+        "@sanity/client": "^7.13.2",
         "@sanity/color": "^3.0.6",
         "@sanity/comlink": "^4.0.1",
-        "@sanity/diff": "4.19.0",
+        "@sanity/diff": "4.21.1",
         "@sanity/diff-match-patch": "^3.2.0",
         "@sanity/diff-patch": "^5.0.0",
         "@sanity/eventsource": "^5.0.2",
-        "@sanity/export": "^4.0.1",
+        "@sanity/export": "^5.0.1",
         "@sanity/icons": "^3.7.4",
         "@sanity/id-utils": "^1.0.0",
-        "@sanity/image-url": "^1.2.0",
+        "@sanity/image-url": "^2.0.1",
         "@sanity/import": "^3.38.3",
         "@sanity/insert-menu": "^2.1.0",
         "@sanity/logos": "^2.2.2",
         "@sanity/media-library-types": "^1.0.1",
         "@sanity/message-protocol": "^0.17.6",
-        "@sanity/migrate": "4.19.0",
-        "@sanity/mutator": "4.19.0",
+        "@sanity/migrate": "4.21.1",
+        "@sanity/mutator": "4.21.1",
         "@sanity/presentation-comlink": "^2.0.1",
         "@sanity/preview-url-secret": "^3.0.0",
-        "@sanity/schema": "4.19.0",
+        "@sanity/schema": "4.21.1",
         "@sanity/sdk": "2.1.2",
         "@sanity/telemetry": "^0.8.0",
-        "@sanity/types": "4.19.0",
-        "@sanity/ui": "^3.1.5",
-        "@sanity/util": "4.19.0",
+        "@sanity/types": "4.21.1",
+        "@sanity/ui": "^3.1.11",
+        "@sanity/util": "4.21.1",
         "@sanity/uuid": "^3.0.2",
         "@sentry/react": "^8.55.0",
         "@tanstack/react-table": "^8.21.3",
         "@tanstack/react-virtual": "^3.13.12",
-        "@types/react-is": "^19.0.0",
+        "@types/react-is": "^19.2.0",
         "@types/shallow-equals": "^1.0.3",
         "@types/speakingurl": "^13.0.6",
         "@types/tar-stream": "^3.1.4",
         "@types/use-sync-external-store": "^1.5.0",
         "@types/which": "^3.0.4",
-        "@vitejs/plugin-react": "^4.6.0",
+        "@vitejs/plugin-react": "^5.1.1",
         "@xstate/react": "^6.0.0",
         "archiver": "^7.0.1",
         "arrify": "^2.0.1",
@@ -15538,16 +16238,16 @@
         "configstore": "^5.0.1",
         "console-table-printer": "^2.14.6",
         "dataloader": "^2.2.3",
-        "date-fns": "^2.30.0",
+        "date-fns": "^4.1.0",
         "debug": "^4.4.3",
         "esbuild": "0.27.0",
         "esbuild-register": "^3.6.0",
         "execa": "^2.1.0",
         "exif-component": "^1.0.1",
         "fast-deep-equal": "3.1.3",
-        "form-data": "^4.0.4",
-        "get-it": "^8.6.10",
-        "groq-js": "^1.21.0",
+        "form-data": "^4.0.5",
+        "get-it": "^8.7.0",
+        "groq-js": "^1.23.0",
         "gunzip-maybe": "^1.4.2",
         "history": "^5.3.0",
         "i18next": "^23.16.8",
@@ -15564,7 +16264,7 @@
         "log-symbols": "^2.2.0",
         "mendoza": "^3.0.8",
         "module-alias": "^2.2.3",
-        "motion": "^12.23.24",
+        "motion": "^12.23.25",
         "nano-pubsub": "^3.0.0",
         "nanoid": "^3.3.11",
         "node-html-parser": "^6.1.13",
@@ -15580,13 +16280,13 @@
         "polished": "^4.3.1",
         "preferred-pm": "^4.1.1",
         "pretty-ms": "^7.0.1",
-        "quick-lru": "^5.1.1",
+        "quick-lru": "^7.3.0",
         "raf": "^3.4.1",
         "react-compiler-runtime": "1.0.0",
         "react-fast-compare": "^3.2.2",
-        "react-focus-lock": "^2.13.6",
+        "react-focus-lock": "^2.13.7",
         "react-i18next": "15.6.1",
-        "react-is": "^19.1.1",
+        "react-is": "^19.2.1",
         "react-refractor": "^4.0.0",
         "react-rx": "^4.2.2",
         "read-pkg-up": "^7.0.1",
@@ -15611,7 +16311,7 @@
         "use-hot-module-reload": "^2.0.0",
         "use-sync-external-store": "^1.6.0",
         "uuid": "^11.1.0",
-        "vite": "^7.1.7",
+        "vite": "^7.2.6",
         "which": "^5.0.0",
         "xstate": "^5.24.0",
         "yargs": "^17.7.2"
@@ -16044,163 +16744,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/sanity/node_modules/@portabletext/block-tools": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@portabletext/block-tools/-/block-tools-4.1.3.tgz",
-      "integrity": "sha512-ow1n/2fKF4sZqbT2gjjmxUcrrHaDzKypbrqkGO/pmgWdD2TBFeDMGLRReRz3WtikcBLe4h+FvctfZwf2lMCAVA==",
-      "license": "MIT",
-      "dependencies": {
-        "@portabletext/sanity-bridge": "^1.2.6",
-        "@portabletext/schema": "^2.0.0",
-        "lodash": "^4.17.21"
-      },
-      "engines": {
-        "node": ">=20.19 <22 || >=22.12"
-      },
-      "peerDependencies": {
-        "@sanity/types": "^4.19.0"
-      }
-    },
-    "node_modules/sanity/node_modules/@portabletext/editor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@portabletext/editor/-/editor-3.1.0.tgz",
-      "integrity": "sha512-2nXxGpyvNHmJJrE8bQZQBoKPMshEMh2vTPnDQh5xzo4ll4f5xr6MxCQuDQCu4BL0jYlE3iEF4s1uLmKkt3dL6w==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@portabletext/block-tools": "^4.1.3",
-        "@portabletext/keyboard-shortcuts": "^2.1.0",
-        "@portabletext/patches": "^2.0.0",
-        "@portabletext/schema": "^2.0.0",
-        "@portabletext/to-html": "^4.0.1",
-        "@xstate/react": "^6.0.0",
-        "debug": "^4.4.3",
-        "immer": "^11.0.0",
-        "lodash": "^4.17.21",
-        "lodash.startcase": "^4.4.0",
-        "react-compiler-runtime": "1.0.0",
-        "slate": "0.118.1",
-        "slate-dom": "^0.119.0",
-        "slate-react": "0.119.0",
-        "xstate": "^5.24.0"
-      },
-      "engines": {
-        "node": ">=20.19 <22 || >=22.12"
-      },
-      "peerDependencies": {
-        "@portabletext/sanity-bridge": "^1.2.6",
-        "@sanity/schema": "^4.19.0",
-        "@sanity/types": "^4.19.0",
-        "react": "^18.3 || ^19",
-        "rxjs": "^7.8.2"
-      }
-    },
-    "node_modules/sanity/node_modules/@portabletext/plugin-character-pair-decorator": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/@portabletext/plugin-character-pair-decorator/-/plugin-character-pair-decorator-4.0.10.tgz",
-      "integrity": "sha512-8bTGJHFeFLbAYIUXNSTczsmIOvAG2mcDIXBDb/Bw776fwj5EzQ3X8zxBOHQJTYAWVRXUPU1AXFxjDy33VRJZtw==",
-      "license": "MIT",
-      "dependencies": {
-        "@xstate/react": "^6.0.0",
-        "react-compiler-runtime": "1.0.0",
-        "remeda": "^2.30.0",
-        "xstate": "^5.24.0"
-      },
-      "engines": {
-        "node": ">=20.19 <22 || >=22.12"
-      },
-      "peerDependencies": {
-        "@portabletext/editor": "^3.1.0",
-        "react": "^18.3 || ^19"
-      }
-    },
-    "node_modules/sanity/node_modules/@portabletext/plugin-input-rule": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@portabletext/plugin-input-rule/-/plugin-input-rule-1.0.10.tgz",
-      "integrity": "sha512-JrpoRc+kCZcrY46XwfqdEZFXhFWjgtcgsvjdTSyspZrnGhLgrAnQi+kEp0C7KR1ugvlNW04onIca0SOTJWx6pw==",
-      "license": "MIT",
-      "dependencies": {
-        "@xstate/react": "^6.0.0",
-        "react-compiler-runtime": "1.0.0",
-        "xstate": "^5.24.0"
-      },
-      "engines": {
-        "node": ">=20.19 <22 || >=22.12"
-      },
-      "peerDependencies": {
-        "@portabletext/editor": "^3.1.0",
-        "react": "^18.3 || ^19"
-      }
-    },
-    "node_modules/sanity/node_modules/@portabletext/plugin-markdown-shortcuts": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/@portabletext/plugin-markdown-shortcuts/-/plugin-markdown-shortcuts-4.0.10.tgz",
-      "integrity": "sha512-ocjlYF1fhCUPJ9NTZEypVicxOD9unsm4vFohUxQpYyhYOpwwDA2NwnkV6WQIZHewZeLIStfFUUJiVV6zHx5UVA==",
-      "license": "MIT",
-      "dependencies": {
-        "@portabletext/plugin-character-pair-decorator": "^4.0.10",
-        "@portabletext/plugin-input-rule": "^1.0.10",
-        "react-compiler-runtime": "1.0.0"
-      },
-      "engines": {
-        "node": ">=20.19 <22 || >=22.12"
-      },
-      "peerDependencies": {
-        "@portabletext/editor": "^3.1.0",
-        "react": "^18.3 || ^19"
-      }
-    },
-    "node_modules/sanity/node_modules/@portabletext/plugin-one-line": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@portabletext/plugin-one-line/-/plugin-one-line-3.0.10.tgz",
-      "integrity": "sha512-91J530OrLzIeOmBmiAIccKPT5UCijRIr1P2U/n8YzDYZB2DkV0m+OTg18sfBpa8DQNJ+rcUXY8WQ0YKXkLbpug==",
-      "license": "MIT",
-      "dependencies": {
-        "react-compiler-runtime": "1.0.0"
-      },
-      "engines": {
-        "node": ">=20.19 <22 || >=22.12"
-      },
-      "peerDependencies": {
-        "@portabletext/editor": "^3.1.0",
-        "react": "^18.3 || ^19"
-      }
-    },
-    "node_modules/sanity/node_modules/@portabletext/plugin-typography": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/@portabletext/plugin-typography/-/plugin-typography-4.0.10.tgz",
-      "integrity": "sha512-eMA7E+cX2gqDO2j6UgxKwrZD5t+1+cn1FTZzq2MslixOTzriNbzaG5ikJE6JUI4v5JOWvbSMc78HFt3NuQLMSw==",
-      "license": "MIT",
-      "dependencies": {
-        "@portabletext/plugin-input-rule": "^1.0.10",
-        "react-compiler-runtime": "1.0.0"
-      },
-      "engines": {
-        "node": ">=20.19 <22 || >=22.12"
-      },
-      "peerDependencies": {
-        "@portabletext/editor": "^3.1.0",
-        "react": "^18.3 || ^19"
-      }
-    },
-    "node_modules/sanity/node_modules/@portabletext/sanity-bridge": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@portabletext/sanity-bridge/-/sanity-bridge-1.2.6.tgz",
-      "integrity": "sha512-metbbn76lwCxk0hzATOjBF9WoWrWmKkbqau+Q1VKHACj3JQ/dIEFD7dE7qutsCY/8Y8fKVVfCW/+HZXPTMe87w==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@portabletext/schema": "^2.0.0",
-        "lodash.startcase": "^4.4.0"
-      },
-      "engines": {
-        "node": ">=20.19 <22 || >=22.12"
-      },
-      "peerDependencies": {
-        "@sanity/schema": "^4.19.0",
-        "@sanity/types": "^4.19.0"
-      }
-    },
     "node_modules/sanity/node_modules/@sanity/asset-utils": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@sanity/asset-utils/-/asset-utils-2.3.0.tgz",
@@ -16211,26 +16754,25 @@
       }
     },
     "node_modules/sanity/node_modules/@sanity/mutator": {
-      "version": "4.19.0",
-      "resolved": "https://registry.npmjs.org/@sanity/mutator/-/mutator-4.19.0.tgz",
-      "integrity": "sha512-V3oDU1+lk5YEogMIcHBS28XnmvOlM+pa+cYaox1EWYIAhlKNdMzfjRFUW8MVI5pfQiK5/OT+knv0l8NdY0cjIA==",
+      "version": "4.21.1",
+      "resolved": "https://registry.npmjs.org/@sanity/mutator/-/mutator-4.21.1.tgz",
+      "integrity": "sha512-i3Fnz5DT94SfQPY4NP84FEzuCjc0eCknZTOUJxP7NImNrKFYPKzyVgDOCJBE6TedA75fWXQSZmAuOR1rwSKhqw==",
       "license": "MIT",
       "dependencies": {
         "@sanity/diff-match-patch": "^3.2.0",
-        "@sanity/types": "4.19.0",
+        "@sanity/types": "4.21.1",
         "@sanity/uuid": "^3.0.2",
         "debug": "^4.4.3",
         "lodash": "^4.17.21"
       }
     },
     "node_modules/sanity/node_modules/@sanity/types": {
-      "version": "4.19.0",
-      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-4.19.0.tgz",
-      "integrity": "sha512-i6o1HREiaccZgMXOj04wuB7Qk9CS79JIA+CSxKxVwDu7UCsNyRtExjVYTlNIA8SkOP/S2ZdPpJOf8uXFsIrXtQ==",
+      "version": "4.21.1",
+      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-4.21.1.tgz",
+      "integrity": "sha512-v0xoriwlg6wtYMIWMy7i6VBfke/Sts/sikwW2Sd+tG55jPGBk25B9N0oymn2YsT6fFsypsP5RqIyByWYSX5lWA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@sanity/client": "^7.12.1",
+        "@sanity/client": "^7.13.2",
         "@sanity/media-library-types": "^1.0.1"
       },
       "peerDependencies": {
@@ -16453,6 +16995,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/sanity/node_modules/quick-lru": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-7.3.0.tgz",
+      "integrity": "sha512-k9lSsjl36EJdK7I06v7APZCbyGT2vMTsYSRX1Q2nbYmnkBqgUhRkAuzH08Ciotteu/PLJmIF2+tti7o3C/ts2g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/sanity/node_modules/react-refractor": {
@@ -16694,15 +17248,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/sha": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/sha/-/sha-3.0.0.tgz",
-      "integrity": "sha512-DOYnM37cNsLNSGIG/zZWch5CKIRNoLdYUQTQlcgkRkoYIUwDYjqDyye16YcDZg/OPdcbUgTKMjc4SY6TB7ZAPw==",
-      "license": "(BSD-2-Clause OR MIT)",
-      "dependencies": {
-        "graceful-fs": "^4.1.2"
-      }
-    },
     "node_modules/sha256-uint8array": {
       "version": "0.10.7",
       "resolved": "https://registry.npmjs.org/sha256-uint8array/-/sha256-uint8array-0.10.7.tgz",
@@ -16831,10 +17376,16 @@
       }
     },
     "node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "license": "ISC"
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/simple-wcswidth": {
       "version": "1.1.2",
@@ -16852,14 +17403,11 @@
       }
     },
     "node_modules/slate": {
-      "version": "0.118.1",
-      "resolved": "https://registry.npmjs.org/slate/-/slate-0.118.1.tgz",
-      "integrity": "sha512-6H1DNgnSwAFhq/pIgf+tLvjNzH912M5XrKKhP9Frmbds2zFXdSJ6L/uFNyVKxQIkPzGWPD0m+wdDfmEuGFH5Tg==",
+      "version": "0.120.0",
+      "resolved": "https://registry.npmjs.org/slate/-/slate-0.120.0.tgz",
+      "integrity": "sha512-CXK/DADGgMZb4z9RTtXylzIDOxvmNJEF9bXV2bAGkLWhQ3rm7GORY9q0H/W41YJvAGZsLbH7nnrhMYr550hWDQ==",
       "license": "MIT",
-      "dependencies": {
-        "immer": "^10.0.3",
-        "tiny-warning": "^1.0.3"
-      }
+      "peer": true
     },
     "node_modules/slate-dom": {
       "version": "0.119.0",
@@ -16889,9 +17437,9 @@
       }
     },
     "node_modules/slate-react": {
-      "version": "0.119.0",
-      "resolved": "https://registry.npmjs.org/slate-react/-/slate-react-0.119.0.tgz",
-      "integrity": "sha512-snHqhQ1NkZXyuqG4JTxywRg1accho/hnioM2JIYqziaQQcgfqLi2Pe1AHL82WIC1pLWdzPjy2O7drnSbO0DBsQ==",
+      "version": "0.120.0",
+      "resolved": "https://registry.npmjs.org/slate-react/-/slate-react-0.120.0.tgz",
+      "integrity": "sha512-CMEJzozriddBjVmbxNvc2erCkXUuEkgdXIdM+jEMvxWMb51z0zhIVzgoxbGprVpzwBXY8Kv7aZOUDVMomzWH/g==",
       "license": "MIT",
       "dependencies": {
         "@juggle/resize-observer": "^3.4.0",
@@ -16905,17 +17453,7 @@
         "react": ">=18.2.0",
         "react-dom": ">=18.2.0",
         "slate": ">=0.114.0",
-        "slate-dom": ">=0.116.0"
-      }
-    },
-    "node_modules/slate/node_modules/immer": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
-      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/immer"
+        "slate-dom": ">=0.119.0"
       }
     },
     "node_modules/source-map": {
@@ -17433,28 +17971,6 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "license": "MIT"
     },
-    "node_modules/symlink-or-copy": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/symlink-or-copy/-/symlink-or-copy-1.3.1.tgz",
-      "integrity": "sha512-0K91MEXFpBUaywiwSSkmKjnGcasG/rVBXFLJz5DrgGabpYD6N+3yZrfD6uUIfpuTu65DZLHi7N8CizHc07BPZA==",
-      "license": "MIT"
-    },
-    "node_modules/tar": {
-      "version": "7.5.2",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.2.tgz",
-      "integrity": "sha512-7NyxrTE4Anh8km8iEy7o0QYPs+0JKBTj5ZaqHg6B39erLg0qYXN3BijtShwbsNSvQ+LN75+KV+C4QR/f6Gwnpg==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/fs-minipass": "^4.0.0",
-        "chownr": "^3.0.0",
-        "minipass": "^7.1.2",
-        "minizlib": "^3.1.0",
-        "yallist": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/tar-fs": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
@@ -17466,12 +17982,6 @@
         "pump": "^3.0.0",
         "tar-stream": "^2.1.4"
       }
-    },
-    "node_modules/tar-fs/node_modules/chownr": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "license": "ISC"
     },
     "node_modules/tar-fs/node_modules/readable-stream": {
       "version": "3.6.2",
@@ -17514,15 +18024,6 @@
         "streamx": "^2.15.0"
       }
     },
-    "node_modules/tar/node_modules/yallist": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
-      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/text-decoder": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
@@ -17559,12 +18060,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.1.tgz",
       "integrity": "sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw==",
-      "license": "MIT"
-    },
-    "node_modules/tiny-warning": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
-      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==",
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
@@ -17899,16 +18394,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.48.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.48.0.tgz",
-      "integrity": "sha512-fcKOvQD9GUn3Xw63EgiDqhvWJ5jsyZUaekl3KVpGsDJnN46WJTe3jWxtQP9lMZm1LJNkFLlTaWAxK2vUQR+cqw==",
+      "version": "8.49.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.49.0.tgz",
+      "integrity": "sha512-zRSVH1WXD0uXczCXw+nsdjGPUdx4dfrs5VQoHnUWmv1U3oNlAKv4FUNdLDhVUg+gYn+a5hUESqch//Rv5wVhrg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.48.0",
-        "@typescript-eslint/parser": "8.48.0",
-        "@typescript-eslint/typescript-estree": "8.48.0",
-        "@typescript-eslint/utils": "8.48.0"
+        "@typescript-eslint/eslint-plugin": "8.49.0",
+        "@typescript-eslint/parser": "8.49.0",
+        "@typescript-eslint/typescript-estree": "8.49.0",
+        "@typescript-eslint/utils": "8.49.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -17921,6 +18416,12 @@
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "license": "MIT"
     },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",
@@ -18063,9 +18564,9 @@
       "license": "ISC"
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.4.tgz",
-      "integrity": "sha512-q0SPT4xyU84saUX+tomz1WLkxUbuaJnR1xWt17M7fJtEJigJeWUNGUqrauFXsHnqev9y9JTRGwk13tFBuKby4A==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.2.tgz",
+      "integrity": "sha512-E85pfNzMQ9jpKkA7+TJAi4TJN+tBCuWh5rUcS/sv6cFi+1q9LYDwDI5dpUL0u/73EElyQ8d3TEaeW4sPedBqYA==",
       "funding": [
         {
           "type": "opencollective",
@@ -18237,9 +18738,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.2.4.tgz",
-      "integrity": "sha512-NL8jTlbo0Tn4dUEXEsUg8KeyG/Lkmc4Fnzb8JXN/Ykm9G4HNImjtABMJgkQoVjOBN/j2WAwDTRytdqJbZsah7w==",
+      "version": "7.2.7",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.2.7.tgz",
+      "integrity": "sha512-ITcnkFeR3+fI8P1wMgItjGrR10170d8auB4EpMLPqmx6uxElH3a/hHGQabSHKdqd4FXWO1nFIp9rRn7JQ34ACQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -18624,17 +19125,17 @@
       "license": "MIT"
     },
     "node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
       "license": "MIT",
       "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
@@ -18679,25 +19180,39 @@
         "node": ">=8"
       }
     },
-    "node_modules/wrap-ansi/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
       "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/wrap-ansi/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+    "node_modules/wrap-ansi/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
       "license": "MIT",
       "dependencies": {
-        "ansi-regex": "^5.0.1"
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/wrappy": {
@@ -18717,6 +19232,12 @@
         "signal-exit": "^3.0.2",
         "typedarray-to-buffer": "^3.1.5"
       }
+    },
+    "node_modules/write-file-atomic/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
     },
     "node_modules/ws": {
       "version": "8.18.3",
@@ -18776,9 +19297,9 @@
       }
     },
     "node_modules/xstate": {
-      "version": "5.24.0",
-      "resolved": "https://registry.npmjs.org/xstate/-/xstate-5.24.0.tgz",
-      "integrity": "sha512-h/213ThFfZbOefUWrLc9ZvYggEVBr0jrD2dNxErxNMLQfZRN19v+80TaXFho17hs8Q2E1mULtm/6nv12um0C4A==",
+      "version": "5.25.0",
+      "resolved": "https://registry.npmjs.org/xstate/-/xstate-5.25.0.tgz",
+      "integrity": "sha512-yyWzfhVRoTHNLjLoMmdwZGagAYfmnzpm9gPjlX2MhJZsDojXGqRxODDOi4BsgGRKD46NZRAdcLp6CKOyvQS0Bw==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -18810,15 +19331,18 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
-      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
       },
       "engines": {
         "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yargs": {
@@ -18917,9 +19441,9 @@
       }
     },
     "node_modules/zustand": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.8.tgz",
-      "integrity": "sha512-gyPKpIaxY9XcO2vSMrLbiER7QMAMGOQZVRdJ6Zi782jkbzZygq5GI9nG8g+sMgitRtndwaBSl7uiqC49o1SSiw==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.9.tgz",
+      "integrity": "sha512-ALBtUj0AfjJt3uNRQoL1tL2tMvj6Gp/6e39dnfT6uzpelGru8v1tPOGBzayOWbPJvujM8JojDk3E1LxeFisBNg==",
       "license": "MIT",
       "engines": {
         "node": ">=12.20.0"


### PR DESCRIPTION
## Summary
- Updates dependencies to resolve 4 high severity glob CLI command injection vulnerabilities (GHSA-5j98-mcp5-4vw2)
- Ran `npm update` to bring all packages to latest compatible versions

## Notes
6 moderate prismjs vulnerabilities remain. These come from `@sanity/cross-dataset-duplicator` being pinned to `@sanity/ui@^2.x` which includes vulnerable prismjs. This requires an upstream fix from the plugin maintainers.

## Test plan
- [ ] Run `npm audit` to verify high severity issues resolved
- [ ] Run `npm run build` to verify studio builds
- [ ] Run `npm run dev` to verify studio runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)