### PR TITLE
Improve event form UX with field groups and better conditional visibility

### DIFF
--- a/schemas/event.js
+++ b/schemas/event.js
@@ -4,23 +4,34 @@ export const event = defineType({
   title: 'Events',
   name: 'event',
   type: 'document',
+  groups: [
+    {name: 'details', title: 'Details', default: true},
+    {name: 'relationships', title: 'Relationships'},
+    {name: 'location', title: 'Location'},
+    {name: 'dates', title: 'Dates'},
+    {name: 'callForSpeakers', title: 'Call for Speakers'},
+  ],
   fields: [
+    // --- Details group ---
     defineField({
       title: 'Title',
       name: 'title',
       type: 'string',
+      group: 'details',
       validation: (Rule) => Rule.required(),
     }),
     defineField({
       title: 'Description',
       name: 'description',
       type: 'text',
+      group: 'details',
       validation: (Rule) => Rule.required(),
     }),
     defineField({
       title: 'Type',
       name: 'type',
       type: 'string',
+      group: 'details',
       initialValue: 'normal',
       options: {
         list: [
@@ -31,37 +42,11 @@ export const event = defineType({
       },
     }),
     defineField({
-      title: 'This is a parent event',
-      name: 'isParent',
-      type: 'boolean',
-      initialValue: false,
-      description: 'Will this event have sub-events?',
-      hidden: ({document}) => document?.type === 'theme',
-    }),
-    defineField({
-      title: 'Part of',
-      name: 'parent',
-      type: 'reference',
-      to: [{type: 'event'}],
-      description: 'If this is part of a larger event, select it here.',
-      hidden: ({document}) => document?.type === 'theme' || document?.isParent === true,
-    }),
-    defineField({
-      title: 'Speakers',
-      name: 'speakers',
-      type: 'array',
-      of: [
-        {
-          type: 'reference',
-          to: [{type: 'person'}],
-        },
-      ],
-      description: 'Add one or more speakers for this event',
-    }),
-    {
       title: 'Format',
       name: 'format',
       type: 'string',
+      group: 'details',
+      hidden: ({document}) => document?.type === 'theme',
       options: {
         list: [
           {title: 'Talk', value: 'talk'},
@@ -77,17 +62,61 @@ export const event = defineType({
           {title: 'Other', value: 'other'},
         ],
       },
-    },
+    }),
     defineField({
       title: 'Free of charge',
       name: 'isFree',
       type: 'boolean',
+      group: 'details',
       initialValue: false,
     }),
+    defineField({
+      title: 'Website',
+      name: 'website',
+      type: 'url',
+      group: 'details',
+    }),
+
+    // --- Relationships group ---
+    defineField({
+      title: 'This is a parent event',
+      name: 'isParent',
+      type: 'boolean',
+      group: 'relationships',
+      initialValue: false,
+      description: 'Will this event have sub-events?',
+      hidden: ({document}) => document?.type === 'theme',
+    }),
+    defineField({
+      title: 'Part of',
+      name: 'parent',
+      type: 'reference',
+      to: [{type: 'event'}],
+      group: 'relationships',
+      description: 'If this is part of a larger event, select it here.',
+      hidden: ({document}) => document?.type === 'theme' || document?.isParent === true,
+    }),
+    defineField({
+      title: 'Speakers',
+      name: 'speakers',
+      type: 'array',
+      of: [
+        {
+          type: 'reference',
+          to: [{type: 'person'}],
+        },
+      ],
+      group: 'relationships',
+      description: 'Add one or more speakers for this event',
+      hidden: ({document}) => document?.type === 'theme',
+    }),
+
+    // --- Location group ---
     defineField({
       title: 'Attendance Mode',
       name: 'attendanceMode',
       type: 'string',
+      group: 'location',
       validation: (Rule) => Rule.required(),
       initialValue: 'none',
       options: {
@@ -99,56 +128,32 @@ export const event = defineType({
         ],
         layout: 'radio',
       },
-      // hide if type is theme
       hidden: ({document}) => document?.type === 'theme',
     }),
     defineField({
       title: 'Location',
       name: 'location',
       type: 'string',
-      hidden: ({document}) => document?.attendanceMode === 'online',
+      group: 'location',
+      hidden: ({document}) => document?.type === 'theme' || document?.attendanceMode === 'online',
     }),
     defineField({
       title: 'Geo location',
       name: 'geopoint',
       type: 'geopoint',
+      group: 'location',
+      hidden: ({document}) =>
+        document?.type === 'theme' ||
+        document?.attendanceMode === 'online' ||
+        document?.attendanceMode === 'none',
     }),
-    // defineField({
-    //   title: "Country",
-    //   name: "country",
-    //   type: "countrieslist",
-    //   options: {
-    //     showStates: false,
-    //     placeholder: 'Select country',
-    //     showIcon: true,
-    //   },
-    // }),
-    defineField({
-      title: 'Website',
-      name: 'website',
-      type: 'url',
-    }),
-    defineField({
-      title: 'Call for speakers',
-      name: 'callForSpeakers',
-      type: 'boolean',
-      initialValue: false,
-      hidden: ({document}) => document?.type === 'theme',
-    }),
-    // Call for speakers closing date
-    defineField({
-      title: 'Call for speakers closing date',
-      name: 'callForSpeakersClosingDate',
-      type: 'datetime',
-      options: {
-        allowTimeZoneSwitch: true,
-      },
-      hidden: ({document}) => document?.callForSpeakers === false,
-    }),
+
+    // --- Dates group ---
     defineField({
       title: 'Scheduled',
       name: 'scheduled',
       type: 'boolean',
+      group: 'dates',
       initialValue: true,
       hidden: ({document}) => !document?.parent || document?.type === 'theme',
     }),
@@ -156,6 +161,7 @@ export const event = defineType({
       title: 'Starts',
       name: 'dateStart',
       type: 'datetime',
+      group: 'dates',
       options: {
         allowTimeZoneSwitch: true,
       },
@@ -165,6 +171,7 @@ export const event = defineType({
       title: 'Ends',
       name: 'dateEnd',
       type: 'datetime',
+      group: 'dates',
       options: {
         allowTimeZoneSwitch: true,
       },
@@ -174,6 +181,7 @@ export const event = defineType({
       title: 'Timezone',
       name: 'timezone',
       type: 'string',
+      group: 'dates',
       description:
         "Must be IANA timezone name (e.g., 'America/New_York', 'Europe/London', 'Asia/Tokyo', 'Australia/Sydney', 'Europe/Berlin', 'Asia/Dubai', 'America/Los_Angeles', 'Europe/Moscow', 'Asia/Kolkata', 'America/New_York', 'America/Los_Angeles'). Cannot use abbreviations (EST, PST, etc.)",
       hidden: ({document}) => document?.scheduled === false,
@@ -182,7 +190,29 @@ export const event = defineType({
       title: 'All day',
       name: 'day',
       type: 'boolean',
+      group: 'dates',
       initialValue: false,
+      hidden: ({document}) => document?.scheduled === false,
+    }),
+
+    // --- Call for Speakers group ---
+    defineField({
+      title: 'Call for speakers',
+      name: 'callForSpeakers',
+      type: 'boolean',
+      group: 'callForSpeakers',
+      initialValue: false,
+      hidden: ({document}) => document?.type === 'theme',
+    }),
+    defineField({
+      title: 'Call for speakers closing date',
+      name: 'callForSpeakersClosingDate',
+      type: 'datetime',
+      group: 'callForSpeakers',
+      options: {
+        allowTimeZoneSwitch: true,
+      },
+      hidden: ({document}) => document?.callForSpeakers === false,
     }),
   ],
   orderings: [


### PR DESCRIPTION
## Summary

- **Field groups (tabs)**: The event form is now organised into 5 tabs — Details, Relationships, Location, Dates, and Call for Speakers — instead of one long scrollable list
- **Smarter conditional visibility**: Fields that aren't relevant to the current event type are now hidden more consistently
- **Minor cleanup**: The `format` field now uses `defineField()` like all other fields

## What to test

### Field groups
Open an event document. You should see 5 tabs at the top of the form. Each tab contains only the fields relevant to that section.

### Theme events
Set the Type to "Theme" and verify:
- **Relationships tab**: `isParent`, `Part of`, and `Speakers` are all hidden
- **Location tab**: `Attendance Mode`, `Location`, and `Geo location` are all hidden
- **Call for Speakers tab**: `Call for speakers` toggle is hidden

### Normal events — online attendance
Set Attendance Mode to "Online" and verify:
- `Location` and `Geo location` are hidden (previously geopoint was always visible)

### Normal events — no attendance mode
Set Attendance Mode to "None" and verify:
- `Geo location` is hidden (no physical location to map)
- `Location` still shows (for descriptive text)

### Dates tab
- When `scheduled` is false (only visible for child events), verify `Starts`, `Ends`, `Timezone`, **and `All day`** are all hidden (previously `All day` stayed visible)

### No data changes
This is a presentation-only change. No fields were added, removed, or renamed. Existing event data is unaffected.