### PR TITLE
Add date validation to event schema

### DIFF
--- a/schemas/event.js
+++ b/schemas/event.js
@@ -166,6 +166,15 @@ export const event = defineType({
         allowTimeZoneSwitch: true,
       },
       hidden: ({document}) => document?.scheduled === false,
+      validation: (Rule) =>
+        Rule.custom((value, context) => {
+          const doc = context.document
+          // Required when the event is scheduled (scheduled defaults to true)
+          if (doc?.scheduled !== false && !value) {
+            return 'A start date is required for scheduled events'
+          }
+          return true
+        }),
     }),
     defineField({
       title: 'Ends',
@@ -176,6 +185,14 @@ export const event = defineType({
         allowTimeZoneSwitch: true,
       },
       hidden: ({document}) => document?.scheduled === false,
+      validation: (Rule) =>
+        Rule.custom((value, context) => {
+          const doc = context.document
+          if (value && doc?.dateStart && new Date(value) <= new Date(doc.dateStart)) {
+            return 'End date must be after the start date'
+          }
+          return true
+        }),
     }),
     defineField({
       title: 'Timezone',


### PR DESCRIPTION
## Summary

- **Require start date for scheduled events**: Shows "A start date is required for scheduled events" when `dateStart` is empty and the event isn't explicitly marked as unscheduled
- **Validate end date is after start date**: Shows "End date must be after the start date" when `dateEnd` is set to a time on or before `dateStart`

## What to test

### Start date required
1. Create a new event (defaults to scheduled)
2. Fill in title and description but leave the start date empty
3. Try to publish — you should see the validation error on the Dates tab

### End date after start date
1. Set a start date (e.g. 1 March 2026 10:00)
2. Set an end date *before* the start date (e.g. 28 February 2026 10:00)
3. You should see the validation error immediately
4. Set the end date equal to the start date — should also error
5. Set the end date after the start date — error clears

### Unscheduled child events
1. Create an event with a parent event set
2. Toggle "Scheduled" to false
3. The date fields hide and the start date validation should NOT trigger

### No data changes
Validation-only change. No fields added, removed, or renamed.