### PR TITLE
feat: add topic document type and topics field on events

### DIFF
--- a/schemas/event.js
+++ b/schemas/event.js
@@ -154,6 +154,19 @@ export const event = defineType({
       to: [{type: 'organizer'}],
       group: 'relationships',
     }),
+    defineField({
+      title: 'Topics',
+      name: 'topics',
+      type: 'array',
+      of: [
+        {
+          type: 'reference',
+          to: [{type: 'topic'}],
+        },
+      ],
+      group: 'relationships',
+      description: 'Link to one or more topics related to this event',
+    }),
 
     // --- Location group ---
     defineField({

--- a/schemas/index.js
+++ b/schemas/index.js
@@ -6,5 +6,6 @@ import person from './person'
 import collection from './collection'
 import book from './book'
 import organizer from './organizer'
+import topic from './topic'
 
-export const schemaTypes = [event, course, provider, person, collection, book, organizer]
+export const schemaTypes = [event, course, provider, person, collection, book, organizer, topic]

--- a/schemas/topic.js
+++ b/schemas/topic.js
@@ -1,0 +1,36 @@
+import {defineType, defineField} from 'sanity'
+
+export const topic = defineType({
+  title: 'Topics',
+  name: 'topic',
+  type: 'document',
+  fields: [
+    defineField({
+      title: 'Name',
+      name: 'name',
+      type: 'string',
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      title: 'Slug',
+      name: 'slug',
+      type: 'slug',
+      options: {
+        source: 'name',
+      },
+    }),
+    defineField({
+      title: 'Body',
+      name: 'body',
+      type: 'array',
+      of: [{type: 'block'}],
+    }),
+  ],
+  preview: {
+    select: {
+      title: 'name',
+    },
+  },
+})
+
+export default topic


### PR DESCRIPTION
## Summary

- Adds a new `topic` document type with `name` (required string), `slug` (sourced from name), and `body` (Portable Text) fields
- Adds a `topics` reference array field to the `event` schema in the Relationships group, allowing any event to link to one or more topics
- Registers the new `topic` schema type in `schemas/index.js`

Closes #208