### PR TITLE
Show location field for theme day events

### DIFF
--- a/schemas/event.js
+++ b/schemas/event.js
@@ -234,7 +234,9 @@ export const event = defineType({
       name: 'location',
       type: 'string',
       group: 'location',
-      hidden: ({document}) => document?.type === 'theme' || document?.attendanceMode === 'online',
+      description:
+        'For awareness/theme days, use the country name (e.g. "UK") if it is not international.',
+      hidden: ({document}) => document?.type !== 'theme' && document?.attendanceMode === 'online',
     }),
     defineField({
       title: 'Geo location',


### PR DESCRIPTION
## Summary

- Fixes the `location` field being hidden when event type is "Theme", which prevented editors from setting a country on awareness/theme days
- Theme days like Dyscalculia Awareness Day (UK) were always displaying as "International" because the location couldn't be set in the Studio
- The hidden condition now only hides the field for online events (where physical location doesn't apply)
- Adds a description hint for editors to explain how to use the field for theme days

## Context

The `location` field's `hidden` callback was `({document}) => document?.type === 'theme' || document?.attendanceMode === 'online'`, which hid it for all theme days. Changed to `({document}) => document?.type !== 'theme' && document?.attendanceMode === 'online'`, so:
- **Theme days**: location is always visible (so you can set "UK", "US", etc.)
- **Normal online events**: location is hidden (no physical location needed)
- **All other events**: location is visible (unchanged behaviour)