### PR TITLE
fix(schema): add missing description field to topic

### DIFF
--- a/schemas/topic.js
+++ b/schemas/topic.js
@@ -20,6 +20,12 @@ export const topic = defineType({
       },
     }),
     defineField({
+      title: 'Description',
+      name: 'description',
+      type: 'text',
+      description: 'Short plain-text summary of this topic, used in listings and metadata.',
+    }),
+    defineField({
       title: 'Body',
       name: 'body',
       type: 'array',


### PR DESCRIPTION
- Adds a `description` field (type `text`) to the `topic` schema
- Fixes a Sanity Studio error reporting the field was not defined in the schema when editing topic documents
- Field shape matches the existing convention in `collection.js`