### PR TITLE
fix(schema): make attendanceMode conditional on event type

### DIFF
--- a/schemas/event.js
+++ b/schemas/event.js
@@ -270,7 +270,11 @@ export const event = defineType({
       name: 'attendanceMode',
       type: 'string',
       group: 'location',
-      validation: (Rule) => Rule.required(),
+      validation: (Rule) =>
+        Rule.custom((value, context) => {
+          if (context.document?.type === 'theme') return true
+          return value ? true : 'Attendance Mode is required'
+        }),
       initialValue: 'none',
       options: {
         list: [
@@ -281,7 +285,6 @@ export const event = defineType({
         ],
         layout: 'radio',
       },
-      hidden: ({document}) => document?.type === 'theme',
     }),
     defineField({
       title: 'Location',


### PR DESCRIPTION
Theme events (awareness days, etc.) hide the Attendance Mode field, but the field was still marked required — so editors of theme events saw an invisible validation error on the Location tab and couldn't publish.

This changes the required rule to a custom validator that short-circuits to valid when `type === 'theme'`, and removes the `hidden` predicate so the field is visible for all event types. `initialValue: 'none'` and the radio options are unchanged.