### PR TITLE
feat(event): add hashtags field

### DIFF
--- a/schemas/event.js
+++ b/schemas/event.js
@@ -151,6 +151,27 @@ export const event = defineType({
         layout: 'tags',
       },
     }),
+    defineField({
+      title: 'Hashtags',
+      name: 'hashtags',
+      type: 'array',
+      of: [{type: 'string'}],
+      group: 'details',
+      description:
+        'Hashtags the organizers use on social media, entered without the # (e.g. a11y, GAAD). ' +
+        'Displayed on the event page on eventua11y.com.',
+      options: {
+        layout: 'tags',
+      },
+      validation: (Rule) =>
+        Rule.custom((tags) => {
+          if (!tags) return true
+          const withHash = tags.filter((tag) => typeof tag === 'string' && tag.includes('#'))
+          return withHash.length
+            ? 'Enter hashtags without the # symbol (e.g. a11y, not #a11y)'
+            : true
+        }),
+    }),
 
     // --- Links group ---
     defineField({


### PR DESCRIPTION
Adds a hashtags field to events so editors can record the hashtags organizers use on social media. These show up on the event page on eventua11y.com.

Hashtags are optional (zero or many) and are stored without the leading `#` so the frontend can render `#{tag}` without ending up with `##`. A validation message nudges editors to leave the `#` off.