### PR TITLE
Require slug in event schema

### DIFF
--- a/schemas/event.js
+++ b/schemas/event.js
@@ -122,6 +122,7 @@ export const event = defineType({
       options: {
         source: 'title',
       },
+      validation: (Rule) => Rule.required(),
     }),
     defineField({
       title: 'Event status',


### PR DESCRIPTION
## Summary
- make the `slug` field required in `schemas/event.js` for `event` documents

## Validation
- `npm run build`
